### PR TITLE
fix: menus not dismissing from canvas clicks

### DIFF
--- a/src/renderer/editor/components/main-toolbar.tsx
+++ b/src/renderer/editor/components/main-toolbar.tsx
@@ -188,32 +188,32 @@ export class MainToolbar extends React.Component<IToolbarProps, IToolbarState> {
 
         return (
             <ButtonGroup large={false} style={{ marginTop: "auto", marginBottom: "auto" }}>
-                <Popover content={project} position={Position.BOTTOM_LEFT}>
+                <Popover content={project} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="folder-open.svg"/>} rightIcon="caret-down" text="File" id="toolbar-files" />
                 </Popover>
-                <Popover content={edit} position={Position.BOTTOM_LEFT}>
+                <Popover content={edit} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="edit.svg"/>} rightIcon="caret-down" text="Edit"/>
                 </Popover>
-                <Popover content={view} position={Position.BOTTOM_LEFT}>
+                <Popover content={view} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="eye.svg"/>} rightIcon="caret-down" text="View"/>
                 </Popover>
-                <Popover content={add} position={Position.BOTTOM_LEFT}>
+                <Popover content={add} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="plus.svg"/>} rightIcon="caret-down" text="Add"/>
                 </Popover>
-                <Popover content={addMesh} position={Position.BOTTOM_LEFT}>
+                <Popover content={addMesh} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="plus.svg"/>} rightIcon="caret-down" text="Add Mesh"/>
                 </Popover>
-                <Popover content={tools} position={Position.BOTTOM_LEFT}>
+                <Popover content={tools} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="wrench.svg"/>} rightIcon="caret-down" text="Tools"/>
                 </Popover>
 
                 {this.state.plugins?.map((p) => (
-                    <Popover content={p.content} position={Position.BOTTOM_LEFT}>
+                    <Popover content={p.content} position={Position.BOTTOM_LEFT} hasBackdrop>
                         <Button icon={p.buttonIcon} rightIcon="caret-down" text={p.buttonLabel}/>
                     </Popover>
                 ))}
 
-                <Popover content={help} position={Position.BOTTOM_LEFT}>
+                <Popover content={help} position={Position.BOTTOM_LEFT} hasBackdrop>
                     <Button icon={<Icon src="dog.svg"/>} rightIcon="caret-down" text="Help"/>
                 </Popover>
             </ButtonGroup>


### PR DESCRIPTION
The Babylon scene by default sets its preventDefaultOnPointerDown
value to true. This causes Blueprint to not observe the mousedown
event it is looking for in order to dismiss an open Popover, like
the ones used for the main toolbar.

This could be solved by setting preventDefaultOnPointerDown to
false, but this could have unanticipated consequences.

Instead, I addressed the issue by adding the `hasBackdrop` prop to
the Blueprint Popover components. This is documented here:

https://blueprintjs.com/docs/#core/components/popover.backdrop

Essentially, this prop adds a click capturing overlay to the app
while the popover is open, causing a click anywhere on the app to
close it -- including the canvas.