### PR TITLE
Fix "nth Person Shooter" naming

### DIFF
--- a/assets/server/templates.json
+++ b/assets/server/templates.json
@@ -1,14 +1,14 @@
 [
     {
-        "name": "Third Personal Shooter",
+        "name": "Third Person Shooter",
         "file": "tps.zip"
     },
     {
-        "name": "First Personal Shooter",
+        "name": "First Person Shooter",
         "file": "fps.zip"
     },
     {
-        "name": "First Personal Shooter Using Graphs (v4.0.0-beta.5)",
+        "name": "First Person Shooter Using Graphs (v4.0.0-beta.5)",
         "file": "fps_graphs.zip"
     }
 ]

--- a/templates/templates.json
+++ b/templates/templates.json
@@ -1,14 +1,14 @@
 [
     {
-        "name": "Third Personal Shooter",
+        "name": "Third Person Shooter",
         "file": "tps.zip"
     },
     {
-        "name": "First Personal Shooter",
+        "name": "First Person Shooter",
         "file": "fps.zip"
     },
     {
-        "name": "First Personal Shooter Using Graphs (v4.0.0-beta.5)",
+        "name": "First Person Shooter Using Graphs (v4.0.0-beta.5)",
         "file": "fps_graphs.zip"
     }
 ]

--- a/website/src/contents/home.tsx
+++ b/website/src/contents/home.tsx
@@ -49,13 +49,13 @@ export class HomeContent extends React.Component {
                             title={<strong className="title">Built-in templates</strong>}
                             description={
                                 <p className="content" style={{ maxWidth: "90%" }}>
-                                    The Editor comes with some built-in projects including Third-Personal-Shooter and First-Personal-Shooter
+                                    The Editor comes with some built-in projects including Third-Person-Shooter and First-Person-Shooter
                                     examples. This is perfect to learn by experimenting using these templates.
                                     {/* <Tree
                                         contents={[
-                                            { label: <a href="./examples/tps/" target="blank">Thrid-Personal-Shooter</a> } as ITreeNode,
-                                            { label: <a href="./examples/fps/" target="blank">First-Personal-Shooter</a> } as ITreeNode,
-                                            { label: <a href="./examples/fps_graphs/" target="blank">First-Personal-Shooter using graphs</a> } as ITreeNode,
+                                            { label: <a href="./examples/tps/" target="blank">Thrid-Person-Shooter</a> } as ITreeNode,
+                                            { label: <a href="./examples/fps/" target="blank">First-Person-Shooter</a> } as ITreeNode,
+                                            { label: <a href="./examples/fps_graphs/" target="blank">First-Person-Shooter using graphs</a> } as ITreeNode,
                                         ]}
                                     /> */}
                                 </p>


### PR DESCRIPTION
Games are typically classified as "nth-Person Shooters". This PR updates the previously-used "Personal" shooter naming convention to match this convention.