### PR TITLE
fix(inspector): Prevent scroll animation when switching objects

### DIFF
--- a/src/renderer/editor/inspectors/abstract-inspector.tsx
+++ b/src/renderer/editor/inspectors/abstract-inspector.tsx
@@ -74,7 +74,7 @@ export abstract class AbstractInspector<T, S> extends React.Component<IObjectIns
 
         // Scroll
         const scrollTop = InspectorUtils.GetInspectorScroll(this._inspectorName);
-        setTimeout(() => this._inspectorDiv?.scroll({ top: scrollTop, behavior: "smooth" }), 0);
+        requestAnimationFrame(() => this._inspectorDiv?.scroll({ top: scrollTop, behavior: "auto" }));
 
         // Listen to events
         InspectorUtils.RegisterInspectorChangedListener(this._inspectorName, (c) => {


### PR DESCRIPTION
When changing between objects in the scene, the inspector area used to play a scroll animation each time an object was selected. This change prevents that animation, and instead keeps the inspector at is current scroll position.