### PR TITLE
allow creating new directories from OpenDirectoryDialog

### DIFF
--- a/src/main/ipc/dialogs.ts
+++ b/src/main/ipc/dialogs.ts
@@ -26,7 +26,7 @@ export class OpenDirectoryDialogIPC implements IIPCHandler {
 	 */
 	public async handler(event: IpcMainEvent, title: string, defaultPath: string): Promise<void> {
         const window = WindowsHandler.GetWindowByWebContentsId(event.sender.id) ?? this._window;
-		const result = await dialog.showOpenDialog(window, { title, defaultPath, properties: ["openDirectory"] });
+		const result = await dialog.showOpenDialog(window, { title, defaultPath, properties: ["openDirectory", "createDirectory"] });
 
 		if (!result || !result.filePaths.length) { return event.sender.send(IPCResponses.CancelOpenFileDialog); }
 		event.sender.send(IPCResponses.OpenDirectoryDialog, result.filePaths[0]);


### PR DESCRIPTION
It may be more convenient to allow users to create new folders when creating new workspace.