### PR TITLE
Tweaks to vscode debugger settings

### DIFF
--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -5,23 +5,24 @@
             "name": "Electron With Devtools",
             "type": "node",
             "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "protocol": "inspector",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
             "windows": {
-                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+                "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
             },
             "env": {
                 "DEBUG": "true",
-                "ONE_WINDOW_AT_A_TIME": "false"
+                "ONE_WINDOW_AT_A_TIME": "false",
             },
             "args": [
                 "--remote-debugging-port=9223",
                 "."
             ],
             "outFiles": [
-                "build/**/*.js"
+                "${workspaceFolder}/build/**/*.js"
             ],
-            "sourceMaps": true
+            "outputCapture": "std",
         },
         {
             "name": "Attach Electron Renderer",
@@ -31,37 +32,37 @@
             "sourceMaps": true,
             "port": 9223,
             "sourceMapPathOverrides": {
-                "file://*": "${workspaceRoot}/src/*",
-                "file://./*": "${workspaceRoot}/src/*",
-            }
+                "file://*": "${workspaceFolder}/src/*",
+                "file://./*": "${workspaceFolder}/src/*",
+            },
+            "internalConsoleOptions": "openOnSessionStart"
         },
         {
             "name": "Electron",
             "type": "node",
             "request": "launch",
-            "cwd": "${workspaceRoot}",
-            "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron",
+            "cwd": "${workspaceFolder}",
+            "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron",
             "windows": {
-                "runtimeExecutable": "${workspaceRoot}/node_modules/.bin/electron.cmd"
+                "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
             },
             "args": [
                 "--remote-debugging-port=9223",
                 "."
             ],
             "outFiles": [
-                "build/**/*.js"
+                "${workspaceFolder}/build/**/*.js"
             ],
-            "sourceMaps": true
         },
         {
             "name": "Run Tests",
             "type": "node",
             "request": "launch",
-            "program": "${workspaceRoot}/node_modules/mocha/bin/_mocha",
+            "program": "${workspaceFolder}/node_modules/mocha/bin/_mocha",
             "stopOnEntry": false,
             "sourceMaps": true,
             "args": [
-                "${workspaceRoot}/build/test/index.js"
+                "${workspaceFolder}/build/test/index.js"
             ],
             "preLaunchTask": "clean-tests",
             "presentation": {
@@ -70,7 +71,7 @@
                 "order": 1
             },
             "console": "internalConsole",
-            "cwd": "${workspaceRoot}",
+            "cwd": "${workspaceFolder}",
             "runtimeExecutable": null,
             "env": {
                 "NODE_ENV": "development"
@@ -79,11 +80,28 @@
     ],
     "compounds": [
         {
+            "name": "Editor With Devtools",
+            "configurations": [
+                "Electron With Devtools",
+                "Attach Electron Renderer"
+            ],
+            "preLaunchTask": "watch",
+            "stopAll": true,
+            "presentation": {
+                "group": "Editor",
+                "order": 1
+            }
+        },
+        {
             "name": "Editor",
             "configurations": [
                 "Electron",
                 "Attach Electron Renderer"
             ],
+            "presentation": {
+                "group": "Editor",
+                "order": 2
+            }
         }
     ]
 }

--- a/.vscode/launch.json
+++ b/.vscode/launch.json
@@ -16,7 +16,6 @@
                 "ONE_WINDOW_AT_A_TIME": "false",
             },
             "args": [
-                "--remote-debugging-port=9223",
                 "."
             ],
             "outFiles": [
@@ -30,7 +29,7 @@
             "request": "attach",
             "webRoot": "${workspaceFolder}",
             "sourceMaps": true,
-            "port": 9223,
+            "port": 8315,
             "sourceMapPathOverrides": {
                 "file://*": "${workspaceFolder}/src/*",
                 "file://./*": "${workspaceFolder}/src/*",
@@ -47,7 +46,6 @@
                 "runtimeExecutable": "${workspaceFolder}/node_modules/.bin/electron.cmd"
             },
             "args": [
-                "--remote-debugging-port=9223",
                 "."
             ],
             "outFiles": [
@@ -80,7 +78,7 @@
     ],
     "compounds": [
         {
-            "name": "Editor With Devtools",
+            "name": "Editor",
             "configurations": [
                 "Electron With Devtools",
                 "Attach Electron Renderer"
@@ -90,17 +88,6 @@
             "presentation": {
                 "group": "Editor",
                 "order": 1
-            }
-        },
-        {
-            "name": "Editor",
-            "configurations": [
-                "Electron",
-                "Attach Electron Renderer"
-            ],
-            "presentation": {
-                "group": "Editor",
-                "order": 2
             }
         }
     ]

--- a/.vscode/tasks.json
+++ b/.vscode/tasks.json
@@ -33,11 +33,12 @@
             "type": "npm",
             "script": "watch",
             "group": "build",
-            "problemMatcher": [],
+            "problemMatcher": "$tsc-watch",
             "presentation": {
-                "panel": "shared",
-                "group": "build"
-            }
+                "panel": "dedicated",
+                "group": "watch",
+            },
+            "isBackground": true
         },
         {
             "label": "watch-sample-plugin",

--- a/src/main/handlers/window.ts
+++ b/src/main/handlers/window.ts
@@ -18,10 +18,6 @@ export class WindowsHandler {
 		const window = this._CreateWindow(definition.options);
 		await this._SetWindowURL(window, definition.url);
 
-		if (process.env.DEBUG) {
-			window.webContents.openDevTools();
-		}
-
 		if (definition.autofocus) {
 			window.focus();
 		}

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -267,9 +267,6 @@ if (shouldQuit) {
 }
 else {
 	app.allowRendererProcessReuse = false;
-
-	// Enable remote debugging
-	app.commandLine.appendSwitch("remote-debugging-port", "8315");
 	
 	// Events
 	app.on("second-instance", (_, argv) => {

--- a/src/main/main.ts
+++ b/src/main/main.ts
@@ -267,6 +267,9 @@ if (shouldQuit) {
 }
 else {
 	app.allowRendererProcessReuse = false;
+
+	// Enable remote debugging of both the Editor and the edited Project.
+	app.commandLine.appendSwitch("remote-debugging-port", "8315");
 	
 	// Events
 	app.on("second-instance", (_, argv) => {


### PR DESCRIPTION
* Start Debugging now starts typescript compilation task (if it's not running)
* Debugger settings changes to fix typescript source debugging from within VSCode
* Capture both Main and Renderer console logs to VSCode Debug Console.
