### PR TITLE
Print Error message when plugin cannot be imported

### DIFF
--- a/src/renderer/windows/preferences/panels/plugins.tsx
+++ b/src/renderer/windows/preferences/panels/plugins.tsx
@@ -103,6 +103,7 @@ export class PluginsPreferencesPanel extends React.Component<IPreferencesPanelPr
 		try {
 			require(folder);
 		} catch (e) {
+			console.error("Error loading plugin", e);
 			return;
 		}
 


### PR DESCRIPTION
When adding a plugin and `require()` throws, this error is swallowed. There is no good way for the plugin developer to know what happened.

This change adds a single console.error() when this happens to print this exception, which provides at least something for the plugin developer to use to figure out what is going wrong.
A better mitigation would be to add an error popup, but I'm not familiar enough with the editor UI to know the best way to do this. I'm opening this PR to start the conversation on this gap.