### PR TITLE
Added feature for assigning node in inspector

### DIFF
--- a/assets/scripts/decorators.ts
+++ b/assets/scripts/decorators.ts
@@ -29,6 +29,10 @@ export interface IVisibleInInspectorOptions {
      * In case of numbers, defines the step applied in the editor.
      */
     step?: number;
+    /**
+     * In case of node, restricts the type of node that can be assigned
+     */
+     allowedNodeType?: "TransformNode" | "Mesh" | "Light" | "Camera";
 }
 
 /**

--- a/assets/scripts/decorators.ts
+++ b/assets/scripts/decorators.ts
@@ -8,7 +8,7 @@ export type VisiblityPropertyType =
     "number" | "string" | "boolean" |
     "Vector2" | "Vector3" | "Vector4" |
     "Color3" | "Color4" |
-    "Texture" |
+    "Texture" | "Node" |
     "KeyMap";
 
 export interface IVisibleInInspectorOptions {

--- a/assets/scripts/tools.ts
+++ b/assets/scripts/tools.ts
@@ -290,7 +290,7 @@ function requireScriptForNodes(scene: Scene, scriptsMap: ISceneScriptMap, nodes:
 
                 case "Color3": n[key] = new Color3(p.value.r, p.value.g, p.value.b); break;
                 case "Color4": n[key] = new Color4(p.value.r, p.value.g, p.value.b, p.value.a); break;
-
+                case "Node": n[key] = scene.getNodeById(p.value); break;
                 default: n[key] = p.value; break;
             }
         }

--- a/doc/04 - attaching-scripts/0-exposing-properties.md
+++ b/doc/04 - attaching-scripts/0-exposing-properties.md
@@ -16,6 +16,7 @@ Suported property types are:
 - Color4
 - Texture
 - KeyMap
+- Node
 
 **Notes: the `KeyMap` type draws a button in the inspector waiting for the user to press a key in the keyboard**
 
@@ -89,3 +90,12 @@ export default class MyMeshComponent extends Mesh {
     }
 }
 ```
+
+## Assigning nodes
+
+In this example we want to assign a node from the scene for an object to follow around. This will default to any object in the scene named "target", until assigned in the inspector. It will only be able to assigned node which inherit from TransformNode.
+
+```typescript
+ @visibleInInspector("Node", "Node to Follow", "target", {allowedNodeType: "TransformNode"})
+  private _targetNode: Nullable<TransformNode>;
+``` 

--- a/src/renderer/editor/components/graph.tsx
+++ b/src/renderer/editor/components/graph.tsx
@@ -28,6 +28,7 @@ import { IDragAndDroppedAssetComponentItem } from "../assets/abstract-assets";
 
 import { GraphContextMenu } from "./graph/context-menu";
 import { GraphReferenceUpdater } from "./graph/reference-updater";
+import { NodeIcon } from "../gui/node-icon";
 
 export interface IGraphProps {
     /**
@@ -752,8 +753,8 @@ export class Graph extends React.Component<IGraphProps, IGraphState> {
             key: node.id,
             isLeaf: !children.length,
             icon: (
-                <Icon
-                    src={this._getIcon(node)}
+                <NodeIcon
+                    node={node}
                     style={{ opacity: node.isEnabled(true) ? "1.0" : "0.5" }}
                     onClick={() => {
                         node.setEnabled(!node.isEnabled());
@@ -779,18 +780,7 @@ export class Graph extends React.Component<IGraphProps, IGraphState> {
         }
     }
 
-    /**
-     * Returns the appropriate icon according to the given node type.
-     * @param node the node reference.
-     */
-    private _getIcon(node: Node): string {
-        if (node instanceof AbstractMesh) { return "vector-square.svg"; }
-        if (node instanceof Light) { return "lightbulb.svg"; }
-        if (node instanceof Camera) { return "camera.svg"; }
-        if (node instanceof Bone) { return "bone.svg"; }
-
-        return "clone.svg";
-    }
+  
 
     /**
      * Called on the user right-clicks on a node.

--- a/src/renderer/editor/components/inspectors/script-inspector.tsx
+++ b/src/renderer/editor/components/inspectors/script-inspector.tsx
@@ -31,6 +31,7 @@ import { AppTools } from "../../tools/app";
 import { SandboxMain, IExportedInspectorValue } from "../../../sandbox/main";
 
 import { AbstractInspector } from "./abstract-inspector";
+import { NodeIcon } from "../../gui/node-icon";
 
 export interface IScriptInspectorState {
     /**
@@ -347,12 +348,27 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
                         <InspectorColor object={property} property="value" label={label} step={iv.options?.step ?? 0.01} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} />
                     );
                     break;
+                case "Node":
+                    property.value ??= property.value ?? iv.defaultValue ?? null;
+                    children.push(
+                        <InspectorList object={property} property="value" label={label} items={() => this.getSceneNodes()} noUndoRedo={true} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} dndHandledTypes={["graph/node"]} />
+                    );
+                    break;
             }
         });
 
         return (
             <InspectorSection title="Exported Values" children={children} />
         );
+    }
+
+    /**
+     * Gets all nodes in the current scene, or returns an empty array if no scene
+     */
+    getSceneNodes(): IInspectorListItem<string>[] {
+        if (!this.editor.scene) return [];
+
+        return this.editor.scene.getNodes().map( node => ({data: node.id, label: node.name, icon: <NodeIcon node={node}></NodeIcon>}))
     }
 
     /**

--- a/src/renderer/editor/components/inspectors/script-inspector.tsx
+++ b/src/renderer/editor/components/inspectors/script-inspector.tsx
@@ -386,7 +386,7 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
     private _getSceneNodes(allowedType?: "TransformNode" | "Mesh" | "Light" | "Camera" | "AbstractMesh"): IInspectorListItem<string>[] {
         if (!this.editor.scene) return [];
         
-        let nodes = this.editor.scene.getNodes()
+        let nodes = this.editor.scene.getNodes();
         if (allowedType) {
             const typeMap = {
               TransformNode: TransformNode,
@@ -399,7 +399,7 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
         }
 
 
-        return nodes.map( node => ({data: node.id, label: node.name, icon: <NodeIcon node={node}></NodeIcon>}))
+        return nodes.map(node => ({ data: node.id, label: node.name, icon: <NodeIcon node={node}></NodeIcon> }));
     }
 
     /**

--- a/src/renderer/editor/components/inspectors/script-inspector.tsx
+++ b/src/renderer/editor/components/inspectors/script-inspector.tsx
@@ -369,7 +369,7 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
                     } 
                   
                     children.push(
-                        <InspectorList object={property} property="value" label={label} items={() => this.getSceneNodes(iv.options?.allowedNodeType)} noUndoRedo={true} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} dndHandledTypes={["graph/node"]} />
+                        <InspectorList object={property} property="value" label={label} items={() => this._getSceneNodes(iv.options?.allowedNodeType)} noUndoRedo={true} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} dndHandledTypes={["graph/node"]} />
                     );
                     break;
             }
@@ -383,7 +383,7 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
     /**
      * Gets all nodes in the current scene, or returns an empty array if no scene
      */
-    getSceneNodes(allowedType?: "TransformNode" | "Mesh" | "Light" | "Camera" | "AbstractMesh"): IInspectorListItem<string>[] {
+    private _getSceneNodes(allowedType?: "TransformNode" | "Mesh" | "Light" | "Camera" | "AbstractMesh"): IInspectorListItem<string>[] {
         if (!this.editor.scene) return [];
         
         let nodes = this.editor.scene.getNodes()

--- a/src/renderer/editor/components/inspectors/script-inspector.tsx
+++ b/src/renderer/editor/components/inspectors/script-inspector.tsx
@@ -8,7 +8,7 @@ import { Nullable } from "../../../../shared/types";
 import * as React from "react";
 import { Classes, Icon, Pre, Spinner, Tooltip } from "@blueprintjs/core";
 
-import { Scene, Node, Vector2, Vector3, Color4 } from "babylonjs";
+import { Scene, Node, Vector2, Vector3, Color4, TransformNode, Light, Camera, Mesh, AbstractMesh } from "babylonjs";
 
 import { IObjectInspectorProps } from "../inspector";
 
@@ -272,6 +272,9 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
             case "Color4":
                 target[propertyKey].copyFrom(value);
                 break;
+            case "Node":
+                target[propertyKey] = this.editor.scene?.getNodeById(value);
+                break;
         }
 
     }
@@ -360,9 +363,13 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
                     );
                     break;
                 case "Node":
-                    property.value ??= property.value ?? iv.defaultValue ?? null;
+                    if (typeof iv.defaultValue == "string") {
+                        const defaultValue = this.editor.scene?.getNodeByName(iv.defaultValue);
+                        property.value ??= property.value ?? defaultValue?.id;
+                    } 
+                  
                     children.push(
-                        <InspectorList object={property} property="value" label={label} items={() => this.getSceneNodes()} noUndoRedo={true} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} dndHandledTypes={["graph/node"]} />
+                        <InspectorList object={property} property="value" label={label} items={() => this.getSceneNodes(iv.options?.allowedNodeType)} noUndoRedo={true} onChange={(v) => this._applyExportedValueInScenePlayer(iv.propertyKey, iv.type, v)} dndHandledTypes={["graph/node"]} />
                     );
                     break;
             }
@@ -376,10 +383,23 @@ export class ScriptInspector<T extends (Scene | Node), S extends IScriptInspecto
     /**
      * Gets all nodes in the current scene, or returns an empty array if no scene
      */
-    getSceneNodes(): IInspectorListItem<string>[] {
+    getSceneNodes(allowedType?: "TransformNode" | "Mesh" | "Light" | "Camera" | "AbstractMesh"): IInspectorListItem<string>[] {
         if (!this.editor.scene) return [];
+        
+        let nodes = this.editor.scene.getNodes()
+        if (allowedType) {
+            const typeMap = {
+              TransformNode: TransformNode,
+              AbstractMesh: AbstractMesh,
+              Mesh: Mesh,
+              Light: Light,
+              Camera: Camera,
+            };
+            nodes = nodes.filter(node => node instanceof typeMap[allowedType])
+        }
 
-        return this.editor.scene.getNodes().map( node => ({data: node.id, label: node.name, icon: <NodeIcon node={node}></NodeIcon>}))
+
+        return nodes.map( node => ({data: node.id, label: node.name, icon: <NodeIcon node={node}></NodeIcon>}))
     }
 
     /**

--- a/src/renderer/editor/gui/inspector/fields/list.tsx
+++ b/src/renderer/editor/gui/inspector/fields/list.tsx
@@ -262,6 +262,7 @@ export class InspectorList<T> extends AbstractFieldComponent<IInspectorListProps
         });
 
         this._initialValue = item.data;
+        this._getCurrentItem();
     }
 
     /**

--- a/src/renderer/editor/gui/node-icon.tsx
+++ b/src/renderer/editor/gui/node-icon.tsx
@@ -11,7 +11,7 @@ export type INodeIconProps = {
 
 export interface INodeIconState {
 
-}
+};
 
 /**
  * Displays an icon to represent a given node based on its type.
@@ -20,7 +20,7 @@ export interface INodeIconState {
 export class NodeIcon extends Component<INodeIconProps, INodeIconState> {
     constructor(props :INodeIconProps) {
         super(props);
-        this.state ={}
+        this.state = {};
     }
 
     render() {

--- a/src/renderer/editor/gui/node-icon.tsx
+++ b/src/renderer/editor/gui/node-icon.tsx
@@ -1,0 +1,50 @@
+import { AbstractMesh, Light, Camera, Bone, Node } from "babylonjs";
+import React, { Component } from "react";
+import { Icon, IIconProps } from "./icon";
+
+export type INodeIconProps = {
+    /**
+     * The node that the icon is based on
+     */
+    node: Node;
+} & Omit<IIconProps, "src">;
+
+export interface INodeIconState {
+
+}
+
+/**
+ * Displays an icon to represent a given node based on its type.
+ * ie. an instance of a camera displays a camera
+ */
+export class NodeIcon extends Component<INodeIconProps, INodeIconState> {
+    constructor(props :INodeIconProps) {
+        super(props);
+        this.state ={}
+    }
+
+    render() {
+        const { node, ...otherProps } = this.props;
+        return <Icon src={NodeIcon.getIconSrc(node)} {...otherProps}></Icon>;
+    }
+
+    /**
+     * Gets the svg source for a given node
+     */
+    public static getIconSrc(node: Node): string {
+        if (node instanceof AbstractMesh)
+            return "vector-square.svg";
+
+        if (node instanceof Light)
+            return "lightbulb.svg";
+
+        if (node instanceof Camera)
+            return "camera.svg";
+
+        if (node instanceof Bone)
+            return "bone.svg";
+
+
+        return "clone.svg";
+    }
+}

--- a/src/renderer/sandbox/main.ts
+++ b/src/renderer/sandbox/main.ts
@@ -37,11 +37,11 @@ export interface IExportedInspectorValue {
     /**
      * Defines the default value of the decorated property.
      */
-    defaultValue: number | string | boolean | Vector2 | Vector3 | Vector4 | Color3 | Color4;
+    defaultValue: number | string | boolean | Vector2 | Vector3 | Vector4 | Color3 | Color4 | Nullable<Node>;
     /**
      * Defines the type of the decorated property.
      */
-    type: "number" | "string" | "boolean" | "KeyMap" | "Vector2" | "Vector3" | "Vector4" | "Color3" | "Color4" | "Texture";
+    type: "number" | "string" | "boolean" | "KeyMap" | "Vector2" | "Vector3" | "Vector4" | "Color3" | "Color4" | "Texture" | "Node";
 
     /**
      * Defines the optional options available for the exported value.

--- a/src/renderer/sandbox/main.ts
+++ b/src/renderer/sandbox/main.ts
@@ -23,6 +23,10 @@ export interface IExportedInspectorValueOptions {
      * In case of numbers, defines the step applied in the editor.
      */
     step?: number;
+    /**
+     * In case of node, restricts the type of node that can be assigned
+     */
+    allowedNodeType?: "TransformNode" | "Mesh" | "Light" | "Camera";
 }
 
 export interface IExportedInspectorValue {
@@ -37,7 +41,7 @@ export interface IExportedInspectorValue {
     /**
      * Defines the default value of the decorated property.
      */
-    defaultValue: number | string | boolean | Vector2 | Vector3 | Vector4 | Color3 | Color4 | Nullable<Node>;
+    defaultValue: number | string | boolean | Vector2 | Vector3 | Vector4 | Color3 | Color4;
     /**
      * Defines the type of the decorated property.
      */


### PR DESCRIPTION
to test add the following to a script
```
    @visibleInInspector("Node")
    private node: Nullable<Node>;
```

works with drag and drop from graph/hierarchy component