### PR TITLE
feature: inspector catches and logs error

### DIFF
--- a/src/renderer/editor/components/inspector.tsx
+++ b/src/renderer/editor/components/inspector.tsx
@@ -193,7 +193,7 @@ export class Inspector extends React.Component<IInspectorProps, IInspectorState>
      * Catches exceptions generated in descendant components. 
      * Unhandled exceptions will cause the entire component tree to unmount.
      */
-    componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+    public componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
         this._editor.console.logError(`inspector failed to load due to error ${error.message} ${errorInfo.componentStack}`);
         throw error;
     }

--- a/src/renderer/editor/components/inspector.tsx
+++ b/src/renderer/editor/components/inspector.tsx
@@ -188,6 +188,16 @@ export class Inspector extends React.Component<IInspectorProps, IInspectorState>
         super.forceUpdate(callback);
     }
 
+
+    /**
+     * Catches exceptions generated in descendant components. 
+     * Unhandled exceptions will cause the entire component tree to unmount.
+     */
+    componentDidCatch(error: Error, errorInfo: React.ErrorInfo): void {
+        this._editor.console.logError(`inspector failed to load due to error ${error.message} ${errorInfo.componentStack}`);
+        throw error;
+    }
+
     /**
      * Sets the selected object in the scene or graph to be edited.
      * @param object the selected object reference used by the inspector to be modified.


### PR DESCRIPTION
Very simple change making it easier to identify why inspector window wont load.

to test just throw an error in some inspector window or its fields then try to load that window