### PR TITLE
feat: tooltip prop for inspector input fields

### DIFF
--- a/src/renderer/editor/gui/inspector/fields/abstract-field.tsx
+++ b/src/renderer/editor/gui/inspector/fields/abstract-field.tsx
@@ -1,6 +1,19 @@
 import * as React from "react";
 
-export class AbstractFieldComponent<P = { }, S = { }> extends React.Component<P, S> {
+/**
+ * Props shared by all input Fields
+ */
+export interface IAbstractFieldProps {
+    /**
+     * Defines the label of the field.
+     */
+    label: string;
+    /**
+     * Defines ToolTip given for the field
+     */
+    toolTip?: string;
+}
+export class AbstractFieldComponent<P, S = { }> extends React.Component<P & IAbstractFieldProps, S> {
     private _isMounted: boolean;
 
     /**

--- a/src/renderer/editor/gui/inspector/fields/boolean.tsx
+++ b/src/renderer/editor/gui/inspector/fields/boolean.tsx
@@ -8,20 +8,15 @@ import { InspectorNotifier } from "../notifier";
 
 import { AbstractFieldComponent } from "./abstract-field";
 
-export interface IInspectorBooleanProps<T> {
+export interface IInspectorBooleanProps {
     /**
      * Defines the reference to the object to modify.
      */
-    object: T;
+    object: any;
     /**
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the field.
-     */
-    label: string;
-
     /**
      * Defines the default value in case of possible undefined/null value.
      */
@@ -55,7 +50,7 @@ export interface IInspectorBooleanState {
     overColor: string;
 }
 
-export class InspectorBoolean<T> extends AbstractFieldComponent<IInspectorBooleanProps<T>, IInspectorBooleanState> {
+export class InspectorBoolean extends AbstractFieldComponent<IInspectorBooleanProps, IInspectorBooleanState> {
     private _input: Nullable<HTMLInputElement> = null;
     private _initialValue: boolean;
 
@@ -65,7 +60,7 @@ export class InspectorBoolean<T> extends AbstractFieldComponent<IInspectorBoolea
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorBooleanProps<T>) {
+    public constructor(props: InspectorBoolean["props"]) {
         super(props);
 
         const value = props.object[props.property] ?? props.defaultValue;
@@ -91,7 +86,7 @@ export class InspectorBoolean<T> extends AbstractFieldComponent<IInspectorBoolea
                 onMouseEnter={() => this.setState({ overColor: "rgba(0, 0, 0, 0.2)" })}
                 onMouseLeave={() => this.setState({ overColor: "rgba(0, 0, 0, 0)" })}
             >
-                <Tooltip content={this.props.label} targetProps={{ style: { width: "100%" } }}>
+                <Tooltip content={this.props.toolTip ?? this.props.label} targetProps={{ style: { width: "100%" } }}>
                     <Switch
                         inputRef={(ref) => this._input = ref}
                         checked={this.state.value}

--- a/src/renderer/editor/gui/inspector/fields/color-picker.tsx
+++ b/src/renderer/editor/gui/inspector/fields/color-picker.tsx
@@ -8,6 +8,7 @@ import { Color3, Color4 } from "babylonjs";
 
 import { InspectorUtils } from "../utils";
 import { InspectorNotifier } from "../notifier";
+import { AbstractFieldComponent } from "./abstract-field";
 
 export interface IColor4Like {
     /**
@@ -37,11 +38,6 @@ export interface IInspectorColorPickerProps {
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the field.
-     */
-    label: string;
-
     /**
      * Defines wether or not the label should be hidden.
      */
@@ -79,7 +75,7 @@ export interface IInspectorColorPickerState {
     textColor: string;
 }
 
-export class InspectorColorPicker extends React.Component<IInspectorColorPickerProps, IInspectorColorPickerState> {
+export class InspectorColorPicker extends AbstractFieldComponent<IInspectorColorPickerProps, IInspectorColorPickerState> {
     private _inspectorName: Nullable<string> = null;
     private _initialValue: Color3 | Color4;
 
@@ -87,7 +83,7 @@ export class InspectorColorPicker extends React.Component<IInspectorColorPickerP
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorColorPickerProps) {
+    public constructor(props: InspectorColorPicker["props"]) {
         super(props);
 
         const value = props.object[props.property] as Color3 | Color4;

--- a/src/renderer/editor/gui/inspector/fields/color.tsx
+++ b/src/renderer/editor/gui/inspector/fields/color.tsx
@@ -2,6 +2,7 @@ import * as React from "react";
 
 import { InspectorNumber } from "./number";
 import { InspectorNotifier } from "../notifier";
+import { AbstractFieldComponent } from "./abstract-field";
 
 export interface IColor4Like {
     /**
@@ -32,10 +33,6 @@ export interface IInspectorColorProps {
      */
     property: string;
     /**
-     * Defines the label of the field.
-     */
-    label: string;
-    /**
      * Defines the step used when dragging the mouse.
      */
     step?: number;
@@ -59,12 +56,12 @@ export interface IInspectorColorState {
     value: IColor4Like;
 }
 
-export class InspectorColor extends React.Component<IInspectorColorProps, IInspectorColorState> {
+export class InspectorColor extends AbstractFieldComponent<IInspectorColorProps, IInspectorColorState> {
     /**
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorColorProps) {
+    public constructor(props: InspectorColor["props"]) {
         super(props);
 
         const value = props.object[props.property];

--- a/src/renderer/editor/gui/inspector/fields/file-input.tsx
+++ b/src/renderer/editor/gui/inspector/fields/file-input.tsx
@@ -5,6 +5,7 @@ import { FileInput, Tooltip } from "@blueprintjs/core";
 
 import { InspectorUtils } from "../utils";
 import { InspectorNotifier } from "../notifier";
+import { AbstractFieldComponent } from "./abstract-field";
 
 export interface IInspectorFileInputProps {
 	/**
@@ -15,11 +16,6 @@ export interface IInspectorFileInputProps {
 	 * Defines the property to edit in the object.
 	 */
 	property: string;
-	/**
-	 * Defines the label of the field.
-	 */
-	label: string;
-
 	/**
 	 * Defines wether or not automatic undo/redo should be skipped.
 	 */
@@ -45,7 +41,7 @@ export interface IInspectorFileInputState {
 	value: string;
 }
 
-export class InspectorFileInput extends React.Component<IInspectorFileInputProps, IInspectorFileInputState> {
+export class InspectorFileInput extends AbstractFieldComponent<IInspectorFileInputProps, IInspectorFileInputState> {
 	private _initialValue: string;
 	private _inspectorName: Nullable<string> = null;
 
@@ -53,7 +49,7 @@ export class InspectorFileInput extends React.Component<IInspectorFileInputProps
 	 * Constructor.
 	 * @param props defines the component's props.
 	 */
-	public constructor(props: IInspectorFileInputProps) {
+	public constructor(props: InspectorFileInput["props"]) {
 		super(props);
 
 		const value = props.object[props.property];
@@ -69,7 +65,7 @@ export class InspectorFileInput extends React.Component<IInspectorFileInputProps
 		return (
 			<div style={{ width: "100%", height: "25px" }}>
 				<div style={{ width: "30%", float: "left", borderLeft: "3px solid #1ed36f", padding: "0 4px 0 5px" }}>
-					<Tooltip content={this.props.label}>
+					<Tooltip content={this.props.toolTip ?? this.props.label}>
 						<span style={{ lineHeight: "30px", textAlign: "center" }}>{this.props.label}</span>
 					</Tooltip>
 				</div>

--- a/src/renderer/editor/gui/inspector/fields/keymap-button.tsx
+++ b/src/renderer/editor/gui/inspector/fields/keymap-button.tsx
@@ -8,19 +8,16 @@ import { InspectorNotifier } from "../notifier";
 
 import { AbstractFieldComponent } from "./abstract-field";
 
-export interface IInspectorKeyMapButtonProps<T> {
+export interface IInspectorKeyMapButtonProps {
     /**
      * Defines the reference to the object to modify.
      */
-    object: T;
+    object: any;
     /**
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the button.
-     */
-    label: string;
+
 
     /**
      * Defines wether or not automatic undo/redo should be skipped.
@@ -43,7 +40,7 @@ export interface IInspectorKeyMapButtonState {
     settingKey: boolean;
 }
 
-export class InspectorKeyMapButton<T> extends AbstractFieldComponent<IInspectorKeyMapButtonProps<T>, IInspectorKeyMapButtonState> {
+export class InspectorKeyMapButton extends AbstractFieldComponent<IInspectorKeyMapButtonProps, IInspectorKeyMapButtonState> {
     private _keyDownListener: Nullable<(ev: KeyboardEvent) => any> = null;
     private _mouseDownListener: Nullable<(ev: MouseEvent) => any> = null;
 
@@ -54,7 +51,7 @@ export class InspectorKeyMapButton<T> extends AbstractFieldComponent<IInspectorK
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorKeyMapButtonProps<T>) {
+    public constructor(props: InspectorKeyMapButton["props"]) {
         super(props);
 
         const value = this.props.object[this.props.property];
@@ -79,7 +76,7 @@ export class InspectorKeyMapButton<T> extends AbstractFieldComponent<IInspectorK
         return (
             <div style={{ width: "100%", height }}>
                 <div style={{ width: "30%", height, float: "left", borderLeft: "3px solid #2FA1D6", padding: "0 4px 0 5px", overflow: "hidden" }}>
-                    <Tooltip content={this.props.label}>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
                         <span style={{ lineHeight: height, textAlign: "center", whiteSpace: "nowrap" }}>{this.props.label}</span>
                     </Tooltip>
                 </div>

--- a/src/renderer/editor/gui/inspector/fields/list.tsx
+++ b/src/renderer/editor/gui/inspector/fields/list.tsx
@@ -40,9 +40,9 @@ export interface IInspectorListProps<T> {
      */
     property: string;
     /**
-     * Defines the label of the field.
+     * Defines a jsx Element to be used as the label. Overrides `label` prop if defined
      */
-    label: string | JSX.Element;
+    labelElement?: JSX.Element;
     /**
      * Defines the list of items drawn in the suggest.
      */
@@ -102,7 +102,7 @@ export class InspectorList<T> extends AbstractFieldComponent<IInspectorListProps
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorListProps<T>) {
+    public constructor(props: InspectorList<T>["props"]) {
         super(props);
 
         this.state = {
@@ -121,8 +121,8 @@ export class InspectorList<T> extends AbstractFieldComponent<IInspectorListProps
         return (
             <div style={{ width: "100%", height: "25px" }}>
                 <div style={{ width: "30%", height: "25px", float: "left", borderLeft: `3px solid ${borderLeftColor}`, padding: "0 4px 0 5px", overflow: "hidden" }}>
-                    <Tooltip content={this.props.label}>
-                        <span style={{ lineHeight: "28px", textAlign: "center", whiteSpace: "nowrap" }}>{this.props.label}</span>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
+                        <span style={{ lineHeight: "28px", textAlign: "center", whiteSpace: "nowrap" }}>{this.props.labelElement ?? this.props.label}</span>
                     </Tooltip>
                 </div>
                 <div

--- a/src/renderer/editor/gui/inspector/fields/number.tsx
+++ b/src/renderer/editor/gui/inspector/fields/number.tsx
@@ -163,7 +163,7 @@ export class InspectorNumber extends AbstractFieldComponent<IInspectorNumberProp
         if (!this.props.noLabel) {
             label = (
                 <div style={{ width: "30%", height: "25px", float: "left", borderLeft: "3px solid #2FA1D6", padding: "0 4px 0 5px", overflow: "hidden" }}>
-                    <Tooltip content={this.props.label}>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
                         <span tabIndex={-1} style={{ lineHeight: "30px", textAlign: "center", whiteSpace: "nowrap" }}>{this.props.label}</span>
                     </Tooltip>
                 </div>

--- a/src/renderer/editor/gui/inspector/fields/string.tsx
+++ b/src/renderer/editor/gui/inspector/fields/string.tsx
@@ -17,10 +17,6 @@ export interface IInspectorStringProps {
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the field.
-     */
-    label: string;
 
     /**
      * Defines wether or not automatic undo/redo should be skipped.
@@ -57,7 +53,7 @@ export class InspectorString extends AbstractFieldComponent<IInspectorStringProp
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorStringProps) {
+    public constructor(props: InspectorString["props"]) {
         super(props);
 
         const value = props.object[props.property];
@@ -77,7 +73,7 @@ export class InspectorString extends AbstractFieldComponent<IInspectorStringProp
         return (
             <div style={{ width: "100%", height: "25px" }}>
                 <div style={{ width: "30%", float: "left", borderLeft: "3px solid #1ed36f", padding: "0 4px 0 5px" }}>
-                    <Tooltip content={this.props.label}>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
                         <span style={{ lineHeight: "30px", textAlign: "center", whiteSpace: "nowrap" }}>{this.props.label}</span>
                     </Tooltip>
                 </div>

--- a/src/renderer/editor/gui/inspector/fields/vector2.tsx
+++ b/src/renderer/editor/gui/inspector/fields/vector2.tsx
@@ -1,4 +1,6 @@
+import { Tooltip } from "@blueprintjs/core";
 import * as React from "react";
+import { AbstractFieldComponent } from "./abstract-field";
 
 import { InspectorNumber } from "./number";
 
@@ -22,10 +24,6 @@ export interface IInspectorVector2Props {
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the field.
-     */
-    label: string;
 
     /**
      * Defines the minimum value of the input.
@@ -59,12 +57,12 @@ export interface IInspectorVector2State {
     value: IVector2Like;
 }
 
-export class InspectorVector2 extends React.Component<IInspectorVector2Props, IInspectorVector2State> {
+export class InspectorVector2 extends AbstractFieldComponent<IInspectorVector2Props, IInspectorVector2State> {
     /**
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorVector2Props) {
+    public constructor(props: InspectorVector2["props"]) {
         super(props);
 
         const value = props.object[props.property];
@@ -82,7 +80,9 @@ export class InspectorVector2 extends React.Component<IInspectorVector2Props, II
         return (
             <div style={{ width: "100%", height: "45px" }}>
                 <div style={{ width: "100%", borderLeft: "3px solid #2FA1D6", padding: "0 4px 0 5px" }}>
-                    <span>{this.props.label}</span>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
+                        <span>{this.props.label}</span>
+                    </Tooltip>
                 </div>
                 <div style={{ float: "left", width: "50%", height: "30px" }}>
                     <InspectorNumber

--- a/src/renderer/editor/gui/inspector/fields/vector3.tsx
+++ b/src/renderer/editor/gui/inspector/fields/vector3.tsx
@@ -2,6 +2,8 @@ import * as React from "react";
 
 import { InspectorNumber } from "./number";
 import { InspectorNotifier } from "../notifier";
+import { Tooltip } from "@blueprintjs/core";
+import { AbstractFieldComponent } from "./abstract-field";
 
 export interface IVector3Like {
     /**
@@ -27,11 +29,6 @@ export interface IInspectorVector3Props {
      * Defines the property to edit in the object.
      */
     property: string;
-    /**
-     * Defines the label of the field.
-     */
-    label: string;
-
     /**
      * Defines the minimum value of the input.
      */
@@ -69,12 +66,12 @@ export interface IInspectorVector3State {
     value: IVector3Like;
 }
 
-export class InspectorVector3 extends React.Component<IInspectorVector3Props, IInspectorVector3State> {
+export class InspectorVector3 extends AbstractFieldComponent<IInspectorVector3Props, IInspectorVector3State> {
     /**
      * Constructor.
      * @param props defines the component's props.
      */
-    public constructor(props: IInspectorVector3Props) {
+    public constructor(props: InspectorVector3["props"]) {
         super(props);
 
         const value = props.object[props.property];
@@ -92,7 +89,9 @@ export class InspectorVector3 extends React.Component<IInspectorVector3Props, II
         return (
             <div style={{ width: "100%", height: "45px" }}>
                 <div style={{ width: "100%", borderLeft: "3px solid #2FA1D6", padding: "0 4px 0 5px" }}>
-                    <span>{this.props.label}</span>
+                    <Tooltip content={this.props.toolTip ?? this.props.label}>
+                        <span>{this.props.label}</span>
+                    </Tooltip>
                 </div>
                 <div style={{ float: "left", width: "33%", height: "30px" }}>
                     <InspectorNumber

--- a/src/renderer/tools/cinematic/panels/tracks.tsx
+++ b/src/renderer/tools/cinematic/panels/tracks.tsx
@@ -272,7 +272,7 @@ export class Tracks extends React.Component<ITracksProps, ITracksState> {
 				case CinematicTrackType.Property:
 					const listLabel = <span>{t.property!.propertyPath}</span>;
 
-					label = <InspectorList key={Tools.RandomId()} object={t.property} property="nodeId" label={listLabel} noUndoRedo borderLeftColor="forestgreen" dndHandledTypes={["graph/node"]} items={() => {
+					label = <InspectorList key={Tools.RandomId()} object={t.property} property="nodeId" label="Track" labelElement={listLabel} noUndoRedo borderLeftColor="forestgreen" dndHandledTypes={["graph/node"]} items={() => {
 						const node = scene?.getNodeById(t.property!.nodeId);
 						return [
 							{ label: node?.name ?? "None", data: node?.id ?? "None" },


### PR DESCRIPTION
Adds tooltip property for all inspector input fields.

Also includes a little bit of refactoring to make AbstractInputComponent more consistantly used.

I plan on adding tooltip to `@visibleInInspector` options once current pull request for that gets resolved