### PR TITLE
Resolves Issue with MacOS when loading ide 

### DIFF
--- a/src/preloaders/editor.ts
+++ b/src/preloaders/editor.ts
@@ -32,9 +32,6 @@ function runEditor(): void {
         if (!(window as any).editor) {
             (window as any).editor = new Editor.default();
         }
-
-        const editorExports = require('../index.js');
-        editorExports.editor = (window as any).editor;
     });
 }
 

--- a/src/preloaders/editor.ts
+++ b/src/preloaders/editor.ts
@@ -1,9 +1,14 @@
 import { join, resolve, basename } from "path";
 
+import { Tools } from "../renderer/editor/tools/tools";
+
 /**
  * When href contains editor.html, let's load the editor itself.
  */
 function runEditor(): void {
+    // Require modules hack for development mode.
+    require('../renderer/module.js');
+
     window["CANNON"] = require("cannon");
 
     const Editor = require('../renderer/editor/index.js');
@@ -39,6 +44,8 @@ function runEditor(): void {
  * When href contains play.html, let's run the project in an isolated iframe.
  */
 function runIsolatedPlay(): void {
+    require('../renderer/module.js');
+
     window.addEventListener("message", function (ev) {
         if (ev.data?.id !== "init") {
             return;
@@ -55,10 +62,6 @@ function runIsolatedPlay(): void {
 }
 
 window.addEventListener("DOMContentLoaded", async () => {
-    // Require modules hack for development mode.
-    require('../renderer/module.js');
-
-    const { Tools } = require("../renderer/editor/tools/tools");
     await Tools.Wait(100);
 
     const htmlFile = basename(window.location.href);


### PR DESCRIPTION
Issue this update resolves [here](https://github.com/BabylonJS/Editor/issues/431)

After the result, it look like this:

https://github.com/BabylonJS/Editor/assets/640305/c5d0800e-96be-4019-98bd-e73436371c10



- resolves macOS errors by enabling the tools wait and reverting a recent change to preload/editor that negatively impacts macOS