### PR TITLE
Fix CameraGizmo disposal issue

### DIFF
--- a/editor/src/editor/layout/preview/gizmo.ts
+++ b/editor/src/editor/layout/preview/gizmo.ts
@@ -106,6 +106,7 @@ export class EditorPreviewGizmo {
 			this._cameraGizmo.attachedNode = node;
 		} else {
 			this._cameraGizmo?.dispose();
+			this._cameraGizmo = null; 
 		}
 
 		if (this.currentGizmo) {


### PR DESCRIPTION
# Fix CameraGizmo disposal issue

## Problem
When switching between camera and non-camera nodes, the `CameraGizmo` was being disposed but the reference wasn't being cleared. This caused issues with the nullish coalescing assignment operator (`??=`) when trying to reuse the gizmo.

## Root Cause
The `setAttachedNode` method was calling `this._cameraGizmo?.dispose()` but not setting `this._cameraGizmo = null` afterward. This left a "dead" reference to the disposed gizmo, causing the `??=` operator to not create a new gizmo when switching back to a camera node.

## Solution
Added `this._cameraGizmo = null` after disposing the gizmo to properly clear the reference.

## Changes
- Modified `setAttachedNode` method to clear the camera gizmo reference after disposal
- This ensures proper cleanup and allows the nullish coalescing assignment to work correctly