### PR TITLE
Refactor: unification of options for dropdowns and context menus

### DIFF
--- a/editor/src/editor/dialogs/command-palette/camera.ts
+++ b/editor/src/editor/dialogs/command-palette/camera.ts
@@ -4,9 +4,30 @@ import { addFreeCamera, addArcRotateCamera } from "../../../project/add/camera";
 
 import { ICommandPaletteType } from "./command-palette";
 
-export function getCameraCommands(editor: Editor): ICommandPaletteType[] {
+export enum CameraKey {
+	ADD_FREE_CAMERA = "add-free-camera",
+	ADD_ARC_ROTATE_CAMERA = "add-arc-rotate-camera",
+}
+
+export enum CameraIPCRendererChannelKey {
+	FREE_CAMERA = "free-camera",
+	ARC_ROTATE_CAMERA = "arc-rotate-camera",
+}
+
+export function getCameraCommands(editor?: Editor): ICommandPaletteType[] {
 	return [
-		{ text: "Add Free Camera", label: "Add a new free camera to the scene", action: () => addFreeCamera(editor) },
-		{ text: "Add Arc Rotate Camera", label: "Add a new arc-rotate camera to the scene", action: () => addArcRotateCamera(editor) },
+		{ 
+			text: "Free Camera", 
+			label: "Add a new free camera to the scene", 
+			key: CameraKey.ADD_FREE_CAMERA, 
+			ipcRendererChannelKey: CameraIPCRendererChannelKey.FREE_CAMERA, 
+			action: () => editor && addFreeCamera(editor) },
+		{ 
+			text: "Arc Rotate Camera", 
+			label: "Add a new arc-rotate camera to the scene", 
+			key: CameraKey.ADD_ARC_ROTATE_CAMERA, 
+			ipcRendererChannelKey: CameraIPCRendererChannelKey.ARC_ROTATE_CAMERA, 
+			action: () => editor && addArcRotateCamera(editor) },
 	];
 }
+

--- a/editor/src/editor/dialogs/command-palette/camera.ts
+++ b/editor/src/editor/dialogs/command-palette/camera.ts
@@ -5,13 +5,13 @@ import { addFreeCamera, addArcRotateCamera } from "../../../project/add/camera";
 import { ICommandPaletteType } from "./command-palette";
 
 export enum CameraKey {
-	ADD_FREE_CAMERA = "add-free-camera",
-	ADD_ARC_ROTATE_CAMERA = "add-arc-rotate-camera",
+	AddFreeCamera = "add-free-camera",
+	AddArcRotateCamera = "add-arc-rotate-camera",
 }
 
 export enum CameraIPCRendererChannelKey {
-	FREE_CAMERA = "free-camera",
-	ARC_ROTATE_CAMERA = "arc-rotate-camera",
+	FreeCamera = "free-camera",
+	ArcRotateCamera = "arc-rotate-camera",
 }
 
 export function getCameraCommands(editor?: Editor): ICommandPaletteType[] {
@@ -19,14 +19,14 @@ export function getCameraCommands(editor?: Editor): ICommandPaletteType[] {
 		{ 
 			text: "Free Camera", 
 			label: "Add a new free camera to the scene", 
-			key: CameraKey.ADD_FREE_CAMERA, 
-			ipcRendererChannelKey: CameraIPCRendererChannelKey.FREE_CAMERA, 
+			key: CameraKey.AddFreeCamera, 
+			ipcRendererChannelKey: CameraIPCRendererChannelKey.FreeCamera, 
 			action: () => editor && addFreeCamera(editor) },
 		{ 
 			text: "Arc Rotate Camera", 
 			label: "Add a new arc-rotate camera to the scene", 
-			key: CameraKey.ADD_ARC_ROTATE_CAMERA, 
-			ipcRendererChannelKey: CameraIPCRendererChannelKey.ARC_ROTATE_CAMERA, 
+			key: CameraKey.AddArcRotateCamera, 
+			ipcRendererChannelKey: CameraIPCRendererChannelKey.ArcRotateCamera, 
 			action: () => editor && addArcRotateCamera(editor) },
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/command-palette.tsx
+++ b/editor/src/editor/dialogs/command-palette/command-palette.tsx
@@ -33,7 +33,9 @@ export interface ICommandPaletteState {
 
 export interface ICommandPaletteType {
 	text: string;
+	key: string;
 	label: string;
+	ipcRendererChannelKey?: string;
 	action: () => unknown;
 }
 
@@ -57,7 +59,7 @@ export class CommandPalette extends Component<ICommandPaletteProps, ICommandPale
 
 					<CommandGroup heading="Commands">
 						{getProjectCommands(this.props.editor).map((command) => (
-							<CommandItem key={command.text} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
+							<CommandItem key={command.key} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
 								<HiMiniCommandLine className="w-10 h-10" /> {command.text}
 							</CommandItem>
 						))}
@@ -65,25 +67,25 @@ export class CommandPalette extends Component<ICommandPaletteProps, ICommandPale
 
 					<CommandGroup heading="Scene">
 						{getLightCommands(this.props.editor).map((command) => (
-							<CommandItem key={command.text} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
+							<CommandItem key={command.key} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
 								<FaCirclePlus className="w-10 h-10" /> {command.text}
 							</CommandItem>
 						))}
 
 						{getMeshCommands(this.props.editor).map((command) => (
-							<CommandItem key={command.text} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
+							<CommandItem key={command.key} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
 								<FaCirclePlus className="w-10 h-10" /> {command.text}
 							</CommandItem>
 						))}
 
 						{getCameraCommands(this.props.editor).map((command) => (
-							<CommandItem key={command.text} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
+							<CommandItem key={command.key} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
 								<FaCirclePlus className="w-10 h-10" /> {command.text}
 							</CommandItem>
 						))}
 
 						{getParticleSystemsCommands(this.props.editor).map((command) => (
-							<CommandItem key={command.text} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
+							<CommandItem key={command.key} onSelect={() => this._executeCommand(command)} className="flex items-center gap-2">
 								<IoSparklesSharp className="w-10 h-10" /> {command.text}
 							</CommandItem>
 						))}
@@ -91,7 +93,7 @@ export class CommandPalette extends Component<ICommandPaletteProps, ICommandPale
 
 					<CommandGroup heading="Files">
 						{this.state.files.map((file) => (
-							<CommandItem key={file.text} onSelect={() => this._executeCommand(file)} className="flex items-center gap-2">
+							<CommandItem key={file.key} onSelect={() => this._executeCommand(file)} className="flex items-center gap-2">
 								<FaFileAlt className="w-10 h-10" /> {file.text}
 							</CommandItem>
 						))}
@@ -128,6 +130,7 @@ export class CommandPalette extends Component<ICommandPaletteProps, ICommandPale
 		});
 
 		const files = glob.map((file) => ({
+			key: basename(file),
 			text: basename(file),
 			label: file.path,
 			action: () => onSelectedAssetChanged.notifyObservers(file),

--- a/editor/src/editor/dialogs/command-palette/light.ts
+++ b/editor/src/editor/dialogs/command-palette/light.ts
@@ -5,17 +5,17 @@ import { addDirectionalLight, addHemisphericLight, addPointLight, addSpotLight }
 import { ICommandPaletteType } from "./command-palette";
 
 export enum LightKey {
-	ADD_POINT_LIGHT = "add-point-light",
-	ADD_DIRECTIONAL_LIGHT = "add-directional-light",
-	ADD_SPOT_LIGHT = "add-spot-light",
-	ADD_HEMISPHERIC_LIGHT = "add-hemispheric-light",
+	AddPointLight = "add-point-light",
+	AddDirectionalLight = "add-directional-light",
+	AddSpotLight = "add-spot-light",
+	AddHemisphericLight = "add-hemispheric-light",
 }
 
 export enum LightIPCRendererChannelKey {
-	POINT_LIGHT = "point-light",
-	DIRECTIONAL_LIGHT = "directional-light",
-	SPOT_LIGHT = "spot-light",
-	HEMISPHERIC_LIGHT = "hemispheric-light",
+	PointLight = "point-light",
+	DirectionalLight = "directional-light",
+	SpotLight = "spot-light",
+	HemisphericLight = "hemispheric-light",
 }
 
 export function getLightCommands(editor?: Editor): ICommandPaletteType[] {
@@ -23,26 +23,26 @@ export function getLightCommands(editor?: Editor): ICommandPaletteType[] {
 		{ 
 			text: "Point Light", 
 			label: "Add a new point light to the scene", 
-			key: LightKey.ADD_POINT_LIGHT, 
-			ipcRendererChannelKey: LightIPCRendererChannelKey.POINT_LIGHT, 
+			key: LightKey.AddPointLight, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.PointLight, 
 			action: () => editor && addPointLight(editor) },
 		{ 
 			text: "Directional Light", 
 			label: "Add a new directional light to the scene", 
-			key: LightKey.ADD_DIRECTIONAL_LIGHT, 
-			ipcRendererChannelKey: LightIPCRendererChannelKey.DIRECTIONAL_LIGHT, 
+			key: LightKey.AddDirectionalLight, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.DirectionalLight,
 			action: () => editor && addDirectionalLight(editor) },
 		{ 
 			text: "Spot Light", 
 			label: "Add a new spot light to the scene", 
-			key: LightKey.ADD_SPOT_LIGHT, 
-			ipcRendererChannelKey: LightIPCRendererChannelKey.SPOT_LIGHT, 
+			key: LightKey.AddSpotLight, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.SpotLight, 
 			action: () => editor && addSpotLight(editor) },
 		{ 
 			text: "Hemispheric Light", 
 			label: "Add a new hemispheric light to the scene", 
-			key: LightKey.ADD_HEMISPHERIC_LIGHT, 
-			ipcRendererChannelKey: LightIPCRendererChannelKey.HEMISPHERIC_LIGHT, 
+			key: LightKey.AddHemisphericLight, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.HemisphericLight, 
 			action: () => editor && addHemisphericLight(editor) },
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/light.ts
+++ b/editor/src/editor/dialogs/command-palette/light.ts
@@ -4,11 +4,45 @@ import { addDirectionalLight, addHemisphericLight, addPointLight, addSpotLight }
 
 import { ICommandPaletteType } from "./command-palette";
 
-export function getLightCommands(editor: Editor): ICommandPaletteType[] {
+export enum LightKey {
+	ADD_POINT_LIGHT = "add-point-light",
+	ADD_DIRECTIONAL_LIGHT = "add-directional-light",
+	ADD_SPOT_LIGHT = "add-spot-light",
+	ADD_HEMISPHERIC_LIGHT = "add-hemispheric-light",
+}
+
+export enum LightIPCRendererChannelKey {
+	POINT_LIGHT = "point-light",
+	DIRECTIONAL_LIGHT = "directional-light",
+	SPOT_LIGHT = "spot-light",
+	HEMISPHERIC_LIGHT = "hemispheric-light",
+}
+
+export function getLightCommands(editor?: Editor): ICommandPaletteType[] {
 	return [
-		{ text: "Add Point Light", label: "Add a new point light to the scene", action: () => addPointLight(editor) },
-		{ text: "Add Directional Light", label: "Add a new directional light to the scene", action: () => addDirectionalLight(editor) },
-		{ text: "Add Spot Light", label: "Add a new spot light to the scene", action: () => addSpotLight(editor) },
-		{ text: "Add Hemispheric Light", label: "Add a new hemispheric light to the scene", action: () => addHemisphericLight(editor) },
+		{ 
+			text: "Point Light", 
+			label: "Add a new point light to the scene", 
+			key: LightKey.ADD_POINT_LIGHT, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.POINT_LIGHT, 
+			action: () => editor && addPointLight(editor) },
+		{ 
+			text: "Directional Light", 
+			label: "Add a new directional light to the scene", 
+			key: LightKey.ADD_DIRECTIONAL_LIGHT, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.DIRECTIONAL_LIGHT, 
+			action: () => editor && addDirectionalLight(editor) },
+		{ 
+			text: "Spot Light", 
+			label: "Add a new spot light to the scene", 
+			key: LightKey.ADD_SPOT_LIGHT, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.SPOT_LIGHT, 
+			action: () => editor && addSpotLight(editor) },
+		{ 
+			text: "Hemispheric Light", 
+			label: "Add a new hemispheric light to the scene", 
+			key: LightKey.ADD_HEMISPHERIC_LIGHT, 
+			ipcRendererChannelKey: LightIPCRendererChannelKey.HEMISPHERIC_LIGHT, 
+			action: () => editor && addHemisphericLight(editor) },
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/material.ts
+++ b/editor/src/editor/dialogs/command-palette/material.ts
@@ -1,0 +1,48 @@
+import { Editor } from "../../main";
+
+import { addPBRMaterial, addStandardMaterial, addNodeMaterial, addSkyMaterial } from "../../../project/add/material";
+
+import { ICommandPaletteType } from "./command-palette";
+
+export enum MaterialKey {
+	ADD_PBR_MATERIAL = "add-pbr-material",
+	ADD_STANDARD_MATERIAL = "add-standard-material",
+	ADD_NODE_MATERIAL = "add-node-material",
+	ADD_SKY_MATERIAL = "add-sky-material",
+}
+
+export enum MaterialIPCRendererChannelKey {
+	PBR_MATERIAL = "pbr-material",
+	STANDARD_MATERIAL = "standard-material",
+	NODE_MATERIAL = "node-material",
+	SKY_MATERIAL = "sky-material",
+}
+
+export function getMaterialCommands(editor?: Editor): ICommandPaletteType[] {
+	return [
+		{ 
+			text: "PBR Material", 
+			label: "Add a new PBR material to the scene", 
+			key: MaterialKey.ADD_PBR_MATERIAL, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.PBR_MATERIAL, 
+			action: () => editor && addPBRMaterial(editor.layout.preview.scene) },
+		{ 
+			text: "Standard Material", 
+			label: "Add a new standard material to the scene", 
+			key: MaterialKey.ADD_STANDARD_MATERIAL, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.STANDARD_MATERIAL, 
+			action: () => editor && addStandardMaterial(editor.layout.preview.scene) },
+		{ 
+			text: "Node Material", 
+			label: "Add a new node material to the scene", 
+			key: MaterialKey.ADD_NODE_MATERIAL, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.NODE_MATERIAL, 
+			action: () => editor && addNodeMaterial(editor.layout.preview.scene) },
+		{ 
+			text: "Sky Material", 
+			label: "Add a new sky material to the scene", 
+			key: MaterialKey.ADD_SKY_MATERIAL, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.SKY_MATERIAL, 
+			action: () => editor && addSkyMaterial(editor.layout.preview.scene) },
+	];
+}

--- a/editor/src/editor/dialogs/command-palette/material.ts
+++ b/editor/src/editor/dialogs/command-palette/material.ts
@@ -5,17 +5,17 @@ import { addPBRMaterial, addStandardMaterial, addNodeMaterial, addSkyMaterial } 
 import { ICommandPaletteType } from "./command-palette";
 
 export enum MaterialKey {
-	ADD_PBR_MATERIAL = "add-pbr-material",
-	ADD_STANDARD_MATERIAL = "add-standard-material",
-	ADD_NODE_MATERIAL = "add-node-material",
-	ADD_SKY_MATERIAL = "add-sky-material",
+	AddPBRMaterial = "add-pbr-material",
+	AddStandardMaterial = "add-standard-material",
+	AddNodeMaterial = "add-node-material",
+	AddSkyMaterial = "add-sky-material",
 }
 
 export enum MaterialIPCRendererChannelKey {
-	PBR_MATERIAL = "pbr-material",
-	STANDARD_MATERIAL = "standard-material",
-	NODE_MATERIAL = "node-material",
-	SKY_MATERIAL = "sky-material",
+	PBRMaterial = "pbr-material",
+	StandardMaterial = "standard-material",
+	NodeMaterial = "node-material",
+	SkyMaterial = "sky-material",
 }
 
 export function getMaterialCommands(editor?: Editor): ICommandPaletteType[] {
@@ -23,26 +23,26 @@ export function getMaterialCommands(editor?: Editor): ICommandPaletteType[] {
 		{ 
 			text: "PBR Material", 
 			label: "Add a new PBR material to the scene", 
-			key: MaterialKey.ADD_PBR_MATERIAL, 
-			ipcRendererChannelKey: MaterialIPCRendererChannelKey.PBR_MATERIAL, 
+			key: MaterialKey.AddPBRMaterial, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.PBRMaterial,
 			action: () => editor && addPBRMaterial(editor.layout.preview.scene) },
 		{ 
 			text: "Standard Material", 
 			label: "Add a new standard material to the scene", 
-			key: MaterialKey.ADD_STANDARD_MATERIAL, 
-			ipcRendererChannelKey: MaterialIPCRendererChannelKey.STANDARD_MATERIAL, 
+			key: MaterialKey.AddStandardMaterial, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.StandardMaterial, 
 			action: () => editor && addStandardMaterial(editor.layout.preview.scene) },
 		{ 
 			text: "Node Material", 
 			label: "Add a new node material to the scene", 
-			key: MaterialKey.ADD_NODE_MATERIAL, 
-			ipcRendererChannelKey: MaterialIPCRendererChannelKey.NODE_MATERIAL, 
+			key: MaterialKey.AddNodeMaterial, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.NodeMaterial, 
 			action: () => editor && addNodeMaterial(editor.layout.preview.scene) },
 		{ 
 			text: "Sky Material", 
 			label: "Add a new sky material to the scene", 
-			key: MaterialKey.ADD_SKY_MATERIAL, 
-			ipcRendererChannelKey: MaterialIPCRendererChannelKey.SKY_MATERIAL, 
+			key: MaterialKey.AddSkyMaterial, 
+			ipcRendererChannelKey: MaterialIPCRendererChannelKey.SkyMaterial, 
 			action: () => editor && addSkyMaterial(editor.layout.preview.scene) },
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/mesh.ts
+++ b/editor/src/editor/dialogs/command-palette/mesh.ts
@@ -7,14 +7,71 @@ import {
 
 import { ICommandPaletteType } from "./command-palette";
 
-export function getMeshCommands(editor: Editor): ICommandPaletteType[] {
+export enum MeshKey {
+	ADD_TRANSFORM_NODE = "add-transform-node",
+	ADD_BOX_MESH = "add-box-mesh",
+	ADD_PLANE_MESH = "add-plane-mesh",
+	ADD_GROUND_MESH = "add-ground-mesh",
+	ADD_SPHERE_MESH = "add-sphere-mesh",
+	ADD_SKYBOX_MESH = "add-skybox-mesh",
+	ADD_EMPTY_MESH = "add-empty-mesh",
+}
+
+export enum MeshIPCRendererChannelKey {
+	TRANSFORM_NODE = "transform-node",
+	BOX_MESH = "box-mesh",
+	PLANE_MESH = "plane-mesh",
+	GROUND_MESH = "ground-mesh",
+	SPHERE_MESH = "sphere-mesh",
+	SKYBOX_MESH = "skybox-mesh",
+	EMPTY_MESH = "empty-mesh",
+}
+
+export function getMeshCommands(editor?: Editor): ICommandPaletteType[] {
 	return [
-		{ text: "Add Transform Node", label: "Add a new transform node to the scene", action: () => addTransformNode(editor) },
-		{ text: "Add Box Mesh", label: "Add a new box mesh to the scene", action: () => addBoxMesh(editor) },
-		{ text: "Add Plane Mesh", label: "Add a new plane mesh to the scene", action: () => addPlaneMesh(editor) },
-		{ text: "Add Ground Mesh", label: "Add a new ground mesh to the scene", action: () => addGroundMesh(editor) },
-		{ text: "Add Sphere Mesh", label: "Add a new sphere mesh to the scene", action: () => addSphereMesh(editor) },
-		{ text: "Add Skybox Mesh", label: "Add a new skybox mesh to the scene", action: () => addSkyboxMesh(editor) },
-		{ text: "Add Empty Mesh", label: "Add a new empty mesh to the scene", action: () => addEmptyMesh(editor) },
+		{ 
+			text: "Transform Node", 
+			label: "Add a new transform node to the scene", 
+			key: MeshKey.ADD_TRANSFORM_NODE, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.TRANSFORM_NODE, 
+			action: () => editor && addTransformNode(editor) },
+		{ 
+			text: "Box Mesh", 
+			label: "Add a new box mesh to the scene", 
+			key: MeshKey.ADD_BOX_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.BOX_MESH,
+			action: () => editor && addBoxMesh(editor) },
+		{ 
+			text: "Plane Mesh", 
+			label: "Add a new plane mesh to the scene", 
+			key: MeshKey.ADD_PLANE_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.PLANE_MESH, 
+			action: () => editor && addPlaneMesh(editor) },
+		{ 
+			text: "Ground Mesh", 
+			label: "Add a new ground mesh to the scene", 
+			key: MeshKey.ADD_GROUND_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.GROUND_MESH, 
+			action: () => editor && addGroundMesh(editor) },
+		{ 
+			text: "Sphere Mesh", 
+			label: "Add a new sphere mesh to the scene", 
+			key: MeshKey.ADD_SPHERE_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.SPHERE_MESH, 
+			action: () => editor && addSphereMesh(editor) },
+		{ 
+			text: "Skybox Mesh", 
+			label: "Add a new skybox mesh to the scene", 
+			key: MeshKey.ADD_SKYBOX_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.SKYBOX_MESH, 
+			action: () => editor && addSkyboxMesh(editor) },
+		{ 
+			text: "Empty Mesh", 
+			label: "Add a new empty mesh to the scene", 
+			key: MeshKey.ADD_EMPTY_MESH, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.EMPTY_MESH, 
+			action: () => editor && addEmptyMesh(editor) },
 	];
 }
+
+

--- a/editor/src/editor/dialogs/command-palette/mesh.ts
+++ b/editor/src/editor/dialogs/command-palette/mesh.ts
@@ -8,23 +8,23 @@ import {
 import { ICommandPaletteType } from "./command-palette";
 
 export enum MeshKey {
-	ADD_TRANSFORM_NODE = "add-transform-node",
-	ADD_BOX_MESH = "add-box-mesh",
-	ADD_PLANE_MESH = "add-plane-mesh",
-	ADD_GROUND_MESH = "add-ground-mesh",
-	ADD_SPHERE_MESH = "add-sphere-mesh",
-	ADD_SKYBOX_MESH = "add-skybox-mesh",
-	ADD_EMPTY_MESH = "add-empty-mesh",
+	AddTransformNode = "add-transform-node",
+	AddBoxMesh = "add-box-mesh",
+	AddPlaneMesh = "add-plane-mesh",
+	AddGroundMesh = "add-ground-mesh",
+	AddSphereMesh = "add-sphere-mesh",
+	AddSkyboxMesh = "add-skybox-mesh",
+	AddEmptyMesh = "add-empty-mesh",
 }
 
 export enum MeshIPCRendererChannelKey {
-	TRANSFORM_NODE = "transform-node",
-	BOX_MESH = "box-mesh",
-	PLANE_MESH = "plane-mesh",
-	GROUND_MESH = "ground-mesh",
-	SPHERE_MESH = "sphere-mesh",
-	SKYBOX_MESH = "skybox-mesh",
-	EMPTY_MESH = "empty-mesh",
+	TransformNode = "transform-node",
+	BoxMesh = "box-mesh",
+	PlaneMesh = "plane-mesh",
+	GroundMesh = "ground-mesh",
+	SphereMesh = "sphere-mesh",
+	SkyboxMesh = "skybox-mesh",
+	EmptyMesh = "empty-mesh",
 }
 
 export function getMeshCommands(editor?: Editor): ICommandPaletteType[] {
@@ -32,44 +32,44 @@ export function getMeshCommands(editor?: Editor): ICommandPaletteType[] {
 		{ 
 			text: "Transform Node", 
 			label: "Add a new transform node to the scene", 
-			key: MeshKey.ADD_TRANSFORM_NODE, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.TRANSFORM_NODE, 
+			key: MeshKey.AddTransformNode, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.TransformNode, 
 			action: () => editor && addTransformNode(editor) },
 		{ 
 			text: "Box Mesh", 
 			label: "Add a new box mesh to the scene", 
-			key: MeshKey.ADD_BOX_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.BOX_MESH,
+			key: MeshKey.AddBoxMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.BoxMesh,
 			action: () => editor && addBoxMesh(editor) },
 		{ 
 			text: "Plane Mesh", 
 			label: "Add a new plane mesh to the scene", 
-			key: MeshKey.ADD_PLANE_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.PLANE_MESH, 
+			key: MeshKey.AddPlaneMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.PlaneMesh, 
 			action: () => editor && addPlaneMesh(editor) },
 		{ 
 			text: "Ground Mesh", 
 			label: "Add a new ground mesh to the scene", 
-			key: MeshKey.ADD_GROUND_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.GROUND_MESH, 
+			key: MeshKey.AddGroundMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.GroundMesh, 
 			action: () => editor && addGroundMesh(editor) },
 		{ 
 			text: "Sphere Mesh", 
 			label: "Add a new sphere mesh to the scene", 
-			key: MeshKey.ADD_SPHERE_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.SPHERE_MESH, 
+			key: MeshKey.AddSphereMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.SphereMesh, 
 			action: () => editor && addSphereMesh(editor) },
 		{ 
 			text: "Skybox Mesh", 
 			label: "Add a new skybox mesh to the scene", 
-			key: MeshKey.ADD_SKYBOX_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.SKYBOX_MESH, 
+			key: MeshKey.AddSkyboxMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.SkyboxMesh, 
 			action: () => editor && addSkyboxMesh(editor) },
 		{ 
 			text: "Empty Mesh", 
 			label: "Add a new empty mesh to the scene", 
-			key: MeshKey.ADD_EMPTY_MESH, 
-			ipcRendererChannelKey: MeshIPCRendererChannelKey.EMPTY_MESH, 
+			key: MeshKey.AddEmptyMesh, 
+			ipcRendererChannelKey: MeshIPCRendererChannelKey.EmptyMesh, 
 			action: () => editor && addEmptyMesh(editor) },
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/particle-systems.ts
+++ b/editor/src/editor/dialogs/command-palette/particle-systems.ts
@@ -3,28 +3,28 @@ import { Editor } from "../../main";
 import { ICommandPaletteType } from "./command-palette";
 
 export enum ParticalSystemKey {
-	RESET_ALL_PARTICLE_SYSTEMS = "reset-all-particle-systems",
-	STOP_ALL_PARTICLE_SYSTEMS = "stop-all-particle-systems",
-	START_ALL_PARTICLE_SYSTEMS = "start-all-particle-systems",
+	ResetAllParticleSystems = "reset-all-particle-systems",
+	StopAllParticleSystems = "stop-all-particle-systems",
+	StartAllParticleSystems = "start-all-particle-systems",
 }
 
 export function getParticleSystemsCommands(editor: Editor): ICommandPaletteType[] {
 	return [
 		{
 			text: "Reset all Particle Systems",
-			key: ParticalSystemKey.RESET_ALL_PARTICLE_SYSTEMS,
+			key: ParticalSystemKey.ResetAllParticleSystems,
 			label: "Reset all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.reset()),
 		},
 		{
 			text: "Stop all Particle Systems",
-			key: ParticalSystemKey.STOP_ALL_PARTICLE_SYSTEMS,
+			key: ParticalSystemKey.StopAllParticleSystems,
 			label: "Stop all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.stop()),
 		},
 		{
 			text: "Start all Particle Systems",
-			key: ParticalSystemKey.START_ALL_PARTICLE_SYSTEMS,
+			key: ParticalSystemKey.StartAllParticleSystems,
 			label: "Start all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.start()),
 		},

--- a/editor/src/editor/dialogs/command-palette/particle-systems.ts
+++ b/editor/src/editor/dialogs/command-palette/particle-systems.ts
@@ -2,20 +2,29 @@ import { Editor } from "../../main";
 
 import { ICommandPaletteType } from "./command-palette";
 
+export enum ParticalSystemKey {
+	RESET_ALL_PARTICLE_SYSTEMS = "reset-all-particle-systems",
+	STOP_ALL_PARTICLE_SYSTEMS = "stop-all-particle-systems",
+	START_ALL_PARTICLE_SYSTEMS = "start-all-particle-systems",
+}
+
 export function getParticleSystemsCommands(editor: Editor): ICommandPaletteType[] {
 	return [
 		{
 			text: "Reset all Particle Systems",
+			key: ParticalSystemKey.RESET_ALL_PARTICLE_SYSTEMS,
 			label: "Reset all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.reset()),
 		},
 		{
 			text: "Stop all Particle Systems",
+			key: ParticalSystemKey.STOP_ALL_PARTICLE_SYSTEMS,
 			label: "Stop all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.stop()),
 		},
 		{
 			text: "Start all Particle Systems",
+			key: ParticalSystemKey.START_ALL_PARTICLE_SYSTEMS,
 			label: "Start all particle systems in the scene",
 			action: () => editor.layout.preview.scene.particleSystems.forEach((ps) => ps.start()),
 		},

--- a/editor/src/editor/dialogs/command-palette/project.ts
+++ b/editor/src/editor/dialogs/command-palette/project.ts
@@ -4,8 +4,17 @@ import { saveProject } from "../../../project/save/save";
 
 import { ICommandPaletteType } from "./command-palette";
 
+export enum ProjectKey {
+	SAVE_PROJECT = "save-project",
+}
+
 export function getProjectCommands(editor: Editor): ICommandPaletteType[] {
 	return [
-		{ text: "Save", label: "Saves the project.", action: () => saveProject(editor) },
+		{ 
+			text: "Save", 
+			label: "Saves the project.", 
+			key: ProjectKey.SAVE_PROJECT, 
+			action: () => saveProject(editor) 
+		},
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/project.ts
+++ b/editor/src/editor/dialogs/command-palette/project.ts
@@ -5,7 +5,7 @@ import { saveProject } from "../../../project/save/save";
 import { ICommandPaletteType } from "./command-palette";
 
 export enum ProjectKey {
-	SAVE_PROJECT = "save-project",
+	SaveProject = "save-project",
 }
 
 export function getProjectCommands(editor: Editor): ICommandPaletteType[] {
@@ -13,7 +13,7 @@ export function getProjectCommands(editor: Editor): ICommandPaletteType[] {
 		{ 
 			text: "Save", 
 			label: "Saves the project.", 
-			key: ProjectKey.SAVE_PROJECT, 
+			key: ProjectKey.SaveProject, 
 			action: () => saveProject(editor) 
 		},
 	];

--- a/editor/src/editor/layout/assets-browser.tsx
+++ b/editor/src/editor/layout/assets-browser.tsx
@@ -37,6 +37,9 @@ import { openMultipleFilesDialog } from "../../tools/dialog";
 import { onSelectedAssetChanged } from "../../tools/observables";
 import { checkProjectCachedCompressedTextures, processingCompressedTextures } from "../../tools/ktx/check";
 
+import { getMaterialCommands } from "../dialogs/command-palette/material";
+import { ICommandPaletteType } from "../dialogs/command-palette/command-palette";
+
 import { loadScene } from "../../project/load/scene";
 import { saveProject } from "../../project/save/save";
 import { onProjectConfigurationChangedObservable, projectConfiguration } from "../../project/configuration";
@@ -69,8 +72,7 @@ import { openModelViewer } from "./assets-browser/viewers/model-viewer";
 import "babylonjs-loaders";
 
 import "../../loader/assimpjs";
-import { getMaterialCommands } from "../dialogs/command-palette/material";
-import { ICommandPaletteType } from "../dialogs/command-palette/command-palette";
+
 
 const HDRSelectable = createSelectable(AssetBrowserHDRItem);
 const GuiSelectable = createSelectable(AssetBrowserGUIItem);
@@ -884,7 +886,7 @@ export class EditorAssetsBrowser extends Component<IEditorAssetsBrowserProps, IE
 			return;
 		}
 
-		const material: Material | null = command.action() as Material;
+		const material = command.action() as Material | null;
 
 		if (!material) {
 			return;

--- a/editor/src/editor/layout/cinematic/inspector/events/apply-impulse.tsx
+++ b/editor/src/editor/layout/cinematic/inspector/events/apply-impulse.tsx
@@ -1,13 +1,13 @@
 import { Scene } from "babylonjs";
 import { ICinematicKeyEvent } from "babylonjs-editor-tools";
 
-import { EditorInspectorNodeField } from "../../../inspector/fields/node";
 import { EditorInspectorVectorField } from "../../../inspector/fields/vector";
 import { EditorInspectorNumberField } from "../../../inspector/fields/number";
+import { EditorInspectorSceneEntityField } from "../../../inspector/fields/entity";
 
 export interface ICinematicEditorApplyImpulseKeyInspectorProps {
-    scene: Scene;
-    cinematicKey: ICinematicKeyEvent;
+	scene: Scene;
+	cinematicKey: ICinematicKeyEvent;
 }
 
 export function CinematicEditorApplyImpulseKeyInspector(props: ICinematicEditorApplyImpulseKeyInspectorProps) {
@@ -17,10 +17,10 @@ export function CinematicEditorApplyImpulseKeyInspector(props: ICinematicEditorA
 			<EditorInspectorVectorField object={props.cinematicKey.data} property="contactPoint" label="Contact Point" />
 
 			{!props.cinematicKey.data.mesh &&
-                <EditorInspectorNumberField object={props.cinematicKey.data} property="radius" label="Radius" min={0} step={0.01} tooltip="Put 0 to ignore the radius and apply impulse on all meshes or selected mesh" />
+				<EditorInspectorNumberField object={props.cinematicKey.data} property="radius" label="Radius" min={0} step={0.01} tooltip="Put 0 to ignore the radius and apply impulse on all meshes or selected mesh" />
 			}
 
-			<EditorInspectorNodeField object={props.cinematicKey.data} property="mesh" scene={props.scene} label="Mesh" />
+			<EditorInspectorSceneEntityField object={props.cinematicKey.data} property="mesh" scene={props.scene} label="Mesh" />
 		</>
 	);
 }

--- a/editor/src/editor/layout/cinematic/inspector/events/set-enabled.tsx
+++ b/editor/src/editor/layout/cinematic/inspector/events/set-enabled.tsx
@@ -1,19 +1,19 @@
 import { Scene } from "babylonjs";
 import { ICinematicKeyEvent } from "babylonjs-editor-tools";
 
-import { EditorInspectorNodeField } from "../../../inspector/fields/node";
 import { EditorInspectorSwitchField } from "../../../inspector/fields/switch";
+import { EditorInspectorSceneEntityField } from "../../../inspector/fields/entity";
 
 export interface ICinematicEditorSetEnabledKeyInspectorProps {
-    scene: Scene;
-    cinematicKey: ICinematicKeyEvent;
+	scene: Scene;
+	cinematicKey: ICinematicKeyEvent;
 }
 
 export function CinematicEditorSetEnabledKeyInspector(props: ICinematicEditorSetEnabledKeyInspectorProps) {
 	return (
 		<>
 			<EditorInspectorSwitchField object={props.cinematicKey.data} property="value" label="Enabled" />
-			<EditorInspectorNodeField object={props.cinematicKey.data} property="node" scene={props.scene} label="Node" />
+			<EditorInspectorSceneEntityField object={props.cinematicKey.data} property="node" scene={props.scene} label="Node" />
 		</>
 	);
 }

--- a/editor/src/editor/layout/graph.tsx
+++ b/editor/src/editor/layout/graph.tsx
@@ -33,13 +33,13 @@ import { isGPUParticleSystem, isParticleSystem } from "../../tools/guards/partic
 import { isAbstractMesh, isCamera, isCollisionInstancedMesh, isCollisionMesh, isEditorCamera, isInstancedMesh, isLight, isMesh, isNode, isTransformNode } from "../../tools/guards/nodes";
 import { onNodeModifiedObservable, onNodesAddedObservable, onParticleSystemAddedObservable, onParticleSystemModifiedObservable, onTextureModifiedObservable } from "../../tools/observables";
 
-import { addArcRotateCamera, addFreeCamera } from "../../project/add/camera";
 import { onProjectConfigurationChangedObservable } from "../../project/configuration";
-import { addDirectionalLight, addHemisphericLight, addPointLight, addSpotLight } from "../../project/add/light";
-import { addBoxMesh, addEmptyMesh, addGroundMesh, addPlaneMesh, addSkyboxMesh, addSphereMesh, addTransformNode } from "../../project/add/mesh";
 
 import { EditorGraphLabel } from "./graph/label";
 import { EditorGraphContextMenu } from "./graph/graph";
+import { getMeshCommands } from "../dialogs/command-palette/mesh";
+import { getLightCommands } from "../dialogs/command-palette/light";
+import { getCameraCommands } from "../dialogs/command-palette/camera";
 
 export interface IEditorGraphProps {
 	/**
@@ -158,7 +158,7 @@ export class EditorGraph extends Component<IEditorGraphProps, IEditorGraphState>
 				/>
 
 				<div
-					className="w-full h-full"
+					className="w-full h-full min-h-20"
 					onDragOver={(ev) => ev.preventDefault()}
 					onDrop={(ev) => this._handleDropEmpty(ev)}
 				>
@@ -172,48 +172,29 @@ export class EditorGraph extends Component<IEditorGraphProps, IEditorGraphState>
 									<AiOutlinePlus className="w-5 h-5" /> Add
 								</ContextMenuSubTrigger>
 								<ContextMenuSubContent>
-									<ContextMenuItem onClick={() => addTransformNode(this.props.editor)}>
-										Transform Node
-									</ContextMenuItem>
+									{getMeshCommands(this.props.editor).map((command) => {
+										return (
+											<ContextMenuItem key={command.key} onClick={command.action}>
+												{command.text}
+											</ContextMenuItem>
+										);
+									})}
 									<ContextMenuSeparator />
-									<ContextMenuItem onClick={() => addBoxMesh(this.props.editor)}>
-										Box Mesh
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addPlaneMesh(this.props.editor)}>
-										Plane Mesh
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addSphereMesh(this.props.editor)}>
-										Sphere Mesh
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addGroundMesh(this.props.editor)}>
-										Ground Mesh
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addSkyboxMesh(this.props.editor)}>
-										SkyBox Mesh
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addEmptyMesh(this.props.editor)}>
-										Empty Mesh
-									</ContextMenuItem>
+									{getLightCommands(this.props.editor).map((command) => {
+										return (
+											<ContextMenuItem key={command.key} onClick={command.action}>
+												{command.text}
+											</ContextMenuItem>
+										);
+									})}
 									<ContextMenuSeparator />
-									<ContextMenuItem onClick={() => addPointLight(this.props.editor)}>
-										Point Light
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addDirectionalLight(this.props.editor)}>
-										Directional Light
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addSpotLight(this.props.editor)}>
-										Spot Light
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addHemisphericLight(this.props.editor)}>
-										Hemispheric Light
-									</ContextMenuItem>
-									<ContextMenuSeparator />
-									<ContextMenuItem onClick={() => addFreeCamera(this.props.editor)}>
-										Free Camera
-									</ContextMenuItem>
-									<ContextMenuItem onClick={() => addArcRotateCamera(this.props.editor)}>
-										Arc Rotate Camera
-									</ContextMenuItem>
+									{getCameraCommands(this.props.editor).map((command) => {
+										return (
+											<ContextMenuItem key={command.key} onClick={command.action}>
+												{command.text}
+											</ContextMenuItem>
+										);
+									})}
 								</ContextMenuSubContent>
 							</ContextMenuSub>
 						</ContextMenuContent>

--- a/editor/src/editor/layout/graph/graph.tsx
+++ b/editor/src/editor/layout/graph/graph.tsx
@@ -21,12 +21,12 @@ import { UniqueNumber, waitNextAnimationFrame } from "../../../tools/tools";
 import { isAbstractMesh, isMesh, isNode } from "../../../tools/guards/nodes";
 
 import { addGPUParticleSystem, addParticleSystem } from "../../../project/add/particles";
-import { addDirectionalLight, addHemisphericLight, addPointLight, addSpotLight } from "../../../project/add/light";
-import { addBoxMesh, addEmptyMesh, addGroundMesh, addPlaneMesh, addSphereMesh, addTransformNode } from "../../../project/add/mesh";
 
 import { Editor } from "../../main";
 
 import { removeNodes } from "./remove";
+import { getMeshCommands } from "../../dialogs/command-palette/mesh";
+import { getLightCommands } from "../../dialogs/command-palette/light";
 
 export interface IEditorGraphContextMenuProps extends PropsWithChildren {
 	editor: Editor;
@@ -81,19 +81,17 @@ export class EditorGraphContextMenu extends Component<IEditorGraphContextMenuPro
 										<AiOutlinePlus className="w-5 h-5" /> Add
 									</ContextMenuSubTrigger>
 									<ContextMenuSubContent>
-										<ContextMenuItem onClick={() => addTransformNode(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Transform Node</ContextMenuItem>
+										{getMeshCommands(this.props.editor).map((command) => (
+											<ContextMenuItem key={command.ipcRendererChannelKey} onClick={command.action}>
+												{command.text}
+											</ContextMenuItem>
+										))}
 										<ContextMenuSeparator />
-										<ContextMenuItem onClick={() => addBoxMesh(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Box</ContextMenuItem>
-										<ContextMenuItem onClick={() => addPlaneMesh(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Plane</ContextMenuItem>
-										<ContextMenuItem onClick={() => addGroundMesh(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Ground</ContextMenuItem>
-										<ContextMenuItem onClick={() => addSphereMesh(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Sphere</ContextMenuItem>
-										<ContextMenuItem onClick={() => addEmptyMesh(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Empty Mesh</ContextMenuItem>
-										<ContextMenuSeparator />
-										<ContextMenuItem onClick={() => addPointLight(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Point Light</ContextMenuItem>
-										<ContextMenuItem onClick={() => addDirectionalLight(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Directional Light</ContextMenuItem>
-										<ContextMenuItem onClick={() => addSpotLight(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Spot Light</ContextMenuItem>
-										<ContextMenuItem onClick={() => addHemisphericLight(this.props.editor, isScene(this.props.object) ? null : this.props.object)}>Hemispheric Light</ContextMenuItem>
-
+										{getLightCommands(this.props.editor).map((command) => (
+											<ContextMenuItem key={command.ipcRendererChannelKey} onClick={command.action}>
+												{command.text}
+											</ContextMenuItem>
+										))}
 										{isAbstractMesh(this.props.object) &&
 											<>
 												<ContextMenuSeparator />

--- a/editor/src/editor/layout/inspector.tsx
+++ b/editor/src/editor/layout/inspector.tsx
@@ -50,7 +50,7 @@ export interface IEditorInspectorState {
 }
 
 export class EditorInspector extends Component<IEditorInspectorProps, IEditorInspectorState> {
-	private static _Inspectors: ((new (props: IEditorInspectorImplementationProps<any>) => Component<IEditorInspectorImplementationProps<any>>) & { IsSupported(object: any): boolean; })[] = [
+	private static _inspectors: ((new (props: IEditorInspectorImplementationProps<any>) => Component<IEditorInspectorImplementationProps<any>>) & { IsSupported(object: any): boolean; })[] = [
 		EditorTransformNodeInspector,
 		EditorMeshInspector,
 
@@ -139,7 +139,7 @@ export class EditorInspector extends Component<IEditorInspectorProps, IEditorIns
 			/>;
 		}
 
-		const inspectors = EditorInspector._Inspectors
+		const inspectors = EditorInspector._inspectors
 			.filter((i) => i.IsSupported(this.state.editedObject))
 			.map((i) => ({ inspector: i }));
 

--- a/editor/src/editor/layout/inspector/fields/entity.tsx
+++ b/editor/src/editor/layout/inspector/fields/entity.tsx
@@ -8,18 +8,23 @@ import { Scene, Node, IParticleSystem, Sound } from "babylonjs";
 import { Button } from "../../../../ui/shadcn/ui/button";
 import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../../ui/shadcn/ui/tooltip";
 
+import { isNode } from "../../../../tools/guards/nodes";
+import { isSound } from "../../../../tools/guards/sound";
 import { getSoundById } from "../../../../tools/sound/tools";
 import { registerSimpleUndoRedo } from "../../../../tools/undoredo";
+import { isAnyParticleSystem } from "../../../../tools/guards/particles";
 import { getInspectorPropertyValue, setInspectorEffectivePropertyValue } from "../../../../tools/property";
 
 import { IEditorInspectorFieldProps } from "./field";
 
-export interface IEditorInspectorNodeFieldProps<T = Node | IParticleSystem | Sound> extends IEditorInspectorFieldProps {
+export interface IEditorInspectorSceneEntityFieldProps<T = Node | IParticleSystem | Sound> extends IEditorInspectorFieldProps {
 	scene: Scene;
+	type?: "node" | "particleSystem" | "sound";
+
 	onChange?: (value: T | null) => void;
 }
 
-export function EditorInspectorNodeField<T extends Node | IParticleSystem | Sound>(props: IEditorInspectorNodeFieldProps<T>) {
+export function EditorInspectorSceneEntityField<T extends Node | IParticleSystem | Sound>(props: IEditorInspectorSceneEntityFieldProps<T>) {
 	const [dragOver, setDragOver] = useState(false);
 	const [value, setValue] = useState<T | null>(null);
 
@@ -65,6 +70,20 @@ export function EditorInspectorNodeField<T extends Node | IParticleSystem | Soun
 		}
 
 		setDragOver(false);
+
+		const entity = getObjectById(data[0]);
+
+		if (props.type === "sound" && !isSound(entity)) {
+			return;
+		}
+
+		if (props.type === "particleSystem" && !isAnyParticleSystem(entity)) {
+			return;
+		}
+
+		if (props.type === "node" && !isNode(entity)) {
+			return;
+		}
 
 		handleSetNode(
 			getObjectById(data[0]),

--- a/editor/src/editor/layout/inspector/mesh/mesh.tsx
+++ b/editor/src/editor/layout/inspector/mesh/mesh.tsx
@@ -169,7 +169,7 @@ export class EditorMeshInspector extends Component<IEditorInspectorImplementatio
 	}
 
 	private _handleAddMaterial(command: ICommandPaletteType): void {
-		if(this.props.object.material) return;
+		if(this.props.object.material) {return;}
 		const material: Material | null = command.action() as Material;
 		
 		if (!material) {

--- a/editor/src/editor/layout/inspector/mesh/mesh.tsx
+++ b/editor/src/editor/layout/inspector/mesh/mesh.tsx
@@ -170,13 +170,22 @@ export class EditorMeshInspector extends Component<IEditorInspectorImplementatio
 
 	private _handleAddMaterial(command: ICommandPaletteType): void {
 		if(this.props.object.material) {return;}
-		const material: Material | null = command.action() as Material;
+		const material = command.action() as Material | null;
 		
 		if (!material) {
 			return;
 		}
 
+
+
 		this.props.object.material = material;
+
+		registerUndoRedo({
+			executeRedo: true,
+			onLost: () => material.dispose(),
+			undo: () => this.props.object.material = null,
+			redo: () => this.props.object.material = material,
+		});
 		this.forceUpdate();
 	}
 

--- a/editor/src/editor/layout/inspector/mesh/mesh.tsx
+++ b/editor/src/editor/layout/inspector/mesh/mesh.tsx
@@ -3,6 +3,7 @@ import { Component, ReactNode } from "react";
 
 import { FaCopy, FaLink } from "react-icons/fa6";
 import { IoAddSharp, IoCloseOutline } from "react-icons/io5";
+import { AiOutlinePlus } from "react-icons/ai";
 
 import { SkyMaterial } from "babylonjs-materials";
 import {
@@ -15,6 +16,7 @@ import { CollisionMesh } from "../../../nodes/collision";
 import { showPrompt } from "../../../../ui/dialog";
 import { Button } from "../../../../ui/shadcn/ui/button";
 import { Separator } from "../../../../ui/shadcn/ui/separator";
+import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuTrigger } from "../../../../ui/shadcn/ui/dropdown-menu";
 
 import { registerUndoRedo } from "../../../../tools/undoredo";
 import { onNodeModifiedObservable } from "../../../../tools/observables";
@@ -45,6 +47,9 @@ import { MeshDecalInspector } from "./decal";
 import { MeshGeometryInspector } from "./geometry";
 import { EditorMeshPhysicsInspector } from "./physics";
 import { EditorMeshCollisionInspector } from "./collision";
+
+import { getMaterialCommands } from "../../../dialogs/command-palette/material";
+import { ICommandPaletteType } from "../../../dialogs/command-palette/command-palette";
 
 export class EditorMeshInspector extends Component<IEditorInspectorImplementationProps<AbstractMesh>> {
 	/**
@@ -163,6 +168,18 @@ export class EditorMeshInspector extends Component<IEditorInspectorImplementatio
 		}
 	}
 
+	private _handleAddMaterial(command: ICommandPaletteType): void {
+		if(this.props.object.material) {return;}
+		const material: Material | null = command.action() as Material;
+		
+		if (!material) {
+			return;
+		}
+
+		this.props.object.material = material;
+		this.forceUpdate();
+	}
+
 	private _getLODsComponent(): ReactNode {
 		const mesh = this.props.object as Mesh;
 
@@ -201,9 +218,26 @@ export class EditorMeshInspector extends Component<IEditorInspectorImplementatio
 		if (!this.props.object.material) {
 			return (
 				<EditorInspectorSectionField title="Material">
-					<div className="text-center text-xl">
-						No material
+					<div className="flex justify-center items-center gap-2">
+						<div className="text-center text-xl">
+                        No material
+						</div>
+						<DropdownMenu>
+							<DropdownMenuTrigger asChild>
+								<Button variant="ghost">
+									<AiOutlinePlus className="w-4 h-4" />
+								</Button>
+							</DropdownMenuTrigger>
+							<DropdownMenuContent>
+								{getMaterialCommands().map((command) => (
+									<DropdownMenuItem key={command.key} onClick={() => this._handleAddMaterial(command)}>
+										{command.text}
+									</DropdownMenuItem>
+								))}
+							</DropdownMenuContent>
+						</DropdownMenu>
 					</div>
+					
 				</EditorInspectorSectionField>
 			);
 		}

--- a/editor/src/editor/layout/inspector/mesh/mesh.tsx
+++ b/editor/src/editor/layout/inspector/mesh/mesh.tsx
@@ -169,7 +169,7 @@ export class EditorMeshInspector extends Component<IEditorInspectorImplementatio
 	}
 
 	private _handleAddMaterial(command: ICommandPaletteType): void {
-		if(this.props.object.material) {return;}
+		if(this.props.object.material) return;
 		const material: Material | null = command.action() as Material;
 		
 		if (!material) {

--- a/editor/src/editor/layout/inspector/script/field.tsx
+++ b/editor/src/editor/layout/inspector/script/field.tsx
@@ -19,6 +19,7 @@ import { ensureTemporaryDirectoryExists } from "../../../../tools/project";
 
 import { projectConfiguration } from "../../../../project/configuration";
 
+import { EditorInspectorListField } from "../fields/list";
 import { EditorInspectorColorField } from "../fields/color";
 import { EditorInspectorSwitchField } from "../fields/switch";
 import { EditorInspectorNumberField } from "../fields/number";
@@ -157,11 +158,19 @@ export function InspectorScriptField(props: IInspectorScriptFieldProps) {
 				);
 
 			case "animationGroup":
-				// TODO: Implement animation group inspector
-				return null;
-
-			default:
-				return null;
+				return (
+					<EditorInspectorListField
+						key={value.propertyKey}
+						object={props.script[scriptValues][value.propertyKey]}
+						property="value"
+						label={value.label ?? value.propertyKey}
+						tooltip={value.configuration.description}
+						items={props.editor.layout.preview.scene.animationGroups.map((animationGroup) => ({
+							text: animationGroup.name,
+							value: animationGroup.name,
+						}))}
+					/>
+				);
 		}
 	}
 

--- a/editor/src/editor/layout/inspector/script/field.tsx
+++ b/editor/src/editor/layout/inspector/script/field.tsx
@@ -19,11 +19,11 @@ import { ensureTemporaryDirectoryExists } from "../../../../tools/project";
 
 import { projectConfiguration } from "../../../../project/configuration";
 
-import { EditorInspectorNodeField } from "../fields/node";
 import { EditorInspectorColorField } from "../fields/color";
 import { EditorInspectorSwitchField } from "../fields/switch";
 import { EditorInspectorNumberField } from "../fields/number";
 import { EditorInspectorVectorField } from "../fields/vector";
+import { EditorInspectorSceneEntityField } from "../fields/entity";
 
 import { VisibleInInspectorDecoratorObject, computeDefaultValuesForObject, scriptValues } from "./tools";
 
@@ -135,8 +135,9 @@ export function InspectorScriptField(props: IInspectorScriptFieldProps) {
 			case "particleSystem":
 			case "sound":
 				return (
-					<EditorInspectorNodeField
+					<EditorInspectorSceneEntityField
 						noUndoRedo
+						type={entityType}
 						key={value.propertyKey}
 						object={props.script[scriptValues][value.propertyKey]}
 						property="value"

--- a/editor/src/editor/layout/preview.tsx
+++ b/editor/src/editor/layout/preview.tsx
@@ -311,7 +311,7 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 		const position = selectedNode.getAbsolutePosition?.();
 		const camera = this.scene.activeCamera;
 		if (position && camera) {
-			Tween.Create(camera, 0.5, {
+			Tween.create(camera, 0.5, {
 				"target": position,
 			});
 		}
@@ -566,7 +566,7 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 	}
 
 	private _highlightCurrentMeshUnderPointer(pickedMesh: AbstractMesh): void {
-		Tween.KillTweensOf(pickedMesh);
+		Tween.killTweensOf(pickedMesh);
 
 		const effectiveMesh = isInstancedMesh(pickedMesh)
 			? pickedMesh.sourceMesh
@@ -583,7 +583,7 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 		}
 
 		meshes.forEach((mesh) => {
-			Tween.Create(mesh, 0.1, {
+			Tween.create(mesh, 0.1, {
 				"overlayAlpha": 0.5,
 				"overlayColor": Color3.Black(),
 				onStart: () => mesh!.renderOverlay = true,
@@ -610,12 +610,12 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 			}
 
 			meshes.forEach((mesh) => {
-				Tween.KillTweensOf(mesh);
+				Tween.killTweensOf(mesh);
 
 				mesh.overlayAlpha ??= 0;
 				mesh.overlayColor ??= Color3.Black();
 
-				Tween.Create(mesh, 0.1, {
+				Tween.create(mesh, 0.1, {
 					"overlayAlpha": 0,
 					"overlayColor": Color3.Black(),
 					onStart: () => mesh.renderOverlay = true,

--- a/editor/src/editor/layout/toolbar.tsx
+++ b/editor/src/editor/layout/toolbar.tsx
@@ -16,38 +16,41 @@ import { ToolbarComponent } from "../../ui/toolbar";
 import { saveProject } from "../../project/save/save";
 import { exportProject } from "../../project/export/export";
 
-import { addArcRotateCamera, addFreeCamera } from "../../project/add/camera";
-import { addDirectionalLight, addHemisphericLight, addPointLight, addSpotLight } from "../../project/add/light";
-import { addTransformNode, addBoxMesh, addGroundMesh, addSphereMesh, addPlaneMesh, addSkyboxMesh, addEmptyMesh } from "../../project/add/mesh";
-
 import { Editor } from "../main";
+import { getLightCommands } from "../dialogs/command-palette/light";
+import { getCameraCommands } from "../dialogs/command-palette/camera";
+import { getMeshCommands } from "../dialogs/command-palette/mesh";
+import { ICommandPaletteType } from "../dialogs/command-palette/command-palette";
 
 export interface IEditorToolbarProps {
 	editor: Editor;
 }
 
 export class EditorToolbar extends Component<IEditorToolbarProps> {
+	private _meshCommands: ICommandPaletteType[] = [];
+	private _lightCommands: ICommandPaletteType[] = [];
+	private _cameraCommands: ICommandPaletteType[] = [];
+
 	public constructor(props: IEditorToolbarProps) {
 		super(props);
+		
 
 		ipcRenderer.on("editor:open-project", () => this._handleOpenProject());
 		ipcRenderer.on("editor:open-vscode", () => this._handleOpenVisualStudioCode());
 
-		ipcRenderer.on("add:transform-node", () => addTransformNode(this.props.editor));
-		ipcRenderer.on("add:box-mesh", () => addBoxMesh(this.props.editor));
-		ipcRenderer.on("add:plane-mesh", () => addPlaneMesh(this.props.editor));
-		ipcRenderer.on("add:sphere-mesh", () => addSphereMesh(this.props.editor));
-		ipcRenderer.on("add:ground-mesh", () => addGroundMesh(this.props.editor));
-		ipcRenderer.on("add:skybox-mesh", () => addSkyboxMesh(this.props.editor));
-		ipcRenderer.on("add:empty-mesh", () => addEmptyMesh(this.props.editor));
+		this._meshCommands = getMeshCommands(this.props.editor);
+		this._lightCommands = getLightCommands(this.props.editor);
+		this._cameraCommands = getCameraCommands(this.props.editor);
 
-		ipcRenderer.on("add:point-light", () => addPointLight(this.props.editor));
-		ipcRenderer.on("add:directional-light", () => addDirectionalLight(this.props.editor));
-		ipcRenderer.on("add:spot-light", () => addSpotLight(this.props.editor));
-		ipcRenderer.on("add:hemispheric-light", () => addHemisphericLight(this.props.editor));
+		const commands = [
+			...this._meshCommands,
+			...this._lightCommands,
+			...this._cameraCommands,
+		];
 
-		ipcRenderer.on("add:free-camera", () => addFreeCamera(this.props.editor));
-		ipcRenderer.on("add:arc-rotate-camera", () => addArcRotateCamera(this.props.editor));
+		for (const command of commands) {
+			ipcRenderer.on(`add:${command.ipcRendererChannelKey}`, command.action);
+		}
 	}
 
 	public render(): ReactNode {
@@ -173,54 +176,23 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 							Add
 						</MenubarTrigger>
 						<MenubarContent className="border-black/50">
-							<MenubarItem onClick={() => addTransformNode(this.props.editor)}>
-								Transform Node
-							</MenubarItem>
-
+							{this._meshCommands.map((command) => (
+								<MenubarItem key={command.key} onClick={command.action}>
+									{command.text}
+								</MenubarItem>
+							))}
 							<MenubarSeparator />
-
-							<MenubarItem onClick={() => addBoxMesh(this.props.editor)}>
-								Box Mesh
-							</MenubarItem>
-							<MenubarItem onClick={() => addPlaneMesh(this.props.editor)}>
-								Plane Mesh
-							</MenubarItem>
-							<MenubarItem onClick={() => addSphereMesh(this.props.editor)}>
-								Sphere Mesh
-							</MenubarItem>
-							<MenubarItem onClick={() => addGroundMesh(this.props.editor)}>
-								Ground Mesh
-							</MenubarItem>
-							<MenubarItem onClick={() => addSkyboxMesh(this.props.editor)}>
-								SkyBox Mesh
-							</MenubarItem>
-							<MenubarItem onClick={() => addEmptyMesh(this.props.editor)}>
-								Empty Mesh
-							</MenubarItem>
-
+							{this._lightCommands.map((command) => (
+								<MenubarItem key={command.key} onClick={command.action}>
+									{command.text}
+								</MenubarItem>
+							))}
 							<MenubarSeparator />
-
-							<MenubarItem onClick={() => addPointLight(this.props.editor)}>
-								Point Light
-							</MenubarItem>
-							<MenubarItem onClick={() => addDirectionalLight(this.props.editor)}>
-								Directional Light
-							</MenubarItem>
-							<MenubarItem onClick={() => addSpotLight(this.props.editor)}>
-								Spot Light
-							</MenubarItem>
-							<MenubarItem onClick={() => addHemisphericLight(this.props.editor)}>
-								Hemispheric Light
-							</MenubarItem>
-
-							<MenubarSeparator />
-
-							<MenubarItem onClick={() => addFreeCamera(this.props.editor)}>
-								Free Camera
-							</MenubarItem>
-							<MenubarItem onClick={() => addArcRotateCamera(this.props.editor)}>
-								Arc Rotate Camera
-							</MenubarItem>
+							{this._cameraCommands.map((command) => (
+								<MenubarItem key={command.key} onClick={command.action}>
+									{command.text}
+								</MenubarItem>
+							))}
 						</MenubarContent>
 					</MenubarMenu>
 

--- a/editor/src/editor/menu.ts
+++ b/editor/src/editor/menu.ts
@@ -1,5 +1,8 @@
 import { platform } from "os";
 import { BrowserWindow, Menu } from "electron";
+import { getMeshCommands } from "./dialogs/command-palette/mesh";
+import { getLightCommands } from "./dialogs/command-palette/light";
+import { getCameraCommands } from "./dialogs/command-palette/camera";
 
 export function setupEditorMenu(): void {
 	Menu.setApplicationMenu(Menu.buildFromTemplate([
@@ -145,64 +148,24 @@ export function setupEditorMenu(): void {
 		{
 			label: "Add",
 			submenu: [
-				{
-					label: "Transform Node",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:transform-node"),
-				},
-				{
-					label: "Box Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:box-mesh"),
-				},
-				{
-					label: "Plane Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:plane-mesh"),
-				},
-				{
-					label: "Sphere Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:sphere-mesh"),
-				},
-				{
-					label: "Ground Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:ground-mesh"),
-				},
-				{
-					label: "SkyBox Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:skybox-mesh"),
-				},
-				{
-					label: "Empty Mesh",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:empty-mesh"),
-				},
+				...getMeshCommands().map((command) => ({
+					label: command.text,
+					click: () => BrowserWindow.getFocusedWindow()?.webContents.send(`add:${command.ipcRendererChannelKey}`),
+				})),
 				{
 					type: "separator",
 				},
-				{
-					label: "Point Light",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:point-light"),
-				},
-				{
-					label: "Directional Light",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:directional-light"),
-				},
-				{
-					label: "Spot Light",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:spot-light"),
-				},
-				{
-					label: "Hemispheric Light",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:hemispheric-light"),
-				},
+				...getLightCommands().map((command) => ({
+					label: command.text,
+					click: () => BrowserWindow.getFocusedWindow()?.webContents.send(`add:${command.ipcRendererChannelKey}`),
+				})),
 				{
 					type: "separator",
 				},
-				{
-					label: "Free Camera",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:free-camera"),
-				},
-				{
-					label: "Arc Rotate Camera",
-					click: () => BrowserWindow.getFocusedWindow()?.webContents.send("add:arc-rotate-camera"),
-				},
+				...getCameraCommands().map((command) => ({
+					label: command.text,
+					click: () => BrowserWindow.getFocusedWindow()?.webContents.send(`add:${command.ipcRendererChannelKey}`),
+				})),
 			],
 		},
 		{

--- a/editor/src/editor/nodes/collision.ts
+++ b/editor/src/editor/nodes/collision.ts
@@ -9,257 +9,257 @@ import { isMesh } from "../../tools/guards/nodes";
 export type CollisionMeshType = "none" | "cube" | "sphere" | "capsule" | "lod";
 
 export class CollisionMesh extends Mesh {
-    @serialize()
+	@serialize()
 	public type: CollisionMeshType = "none";
 
-    /**
-     * Constructor
-     * @param name The value used by scene.getMeshByName() to do a lookup.
-     * @param scene The scene to add this mesh to.
-     * @param parent The parent of this mesh, if it has one
-     * @param source An optional Mesh from which geometry is shared, cloned.
-     * @param doNotCloneChildren When cloning, skip cloning child meshes of source, default False.
-     *                  When false, achieved by calling a clone(), also passing False.
-     *                  This will make creation of children, recursive.
-     * @param clonePhysicsImpostor When cloning, include cloning mesh physics impostor, default True.
-     */
-    public constructor(
-    	name: string,
-    	scene: Scene,
-    	parent?: Node | null,
-    	source?: Mesh | null,
-    	doNotCloneChildren?: boolean,
-    	clonePhysicsImpostor?: boolean,
-    ) {
-    	super(name, scene, parent, source, doNotCloneChildren, clonePhysicsImpostor);
+	/**
+	 * Constructor
+	 * @param name The value used by scene.getMeshByName() to do a lookup.
+	 * @param scene The scene to add this mesh to.
+	 * @param parent The parent of this mesh, if it has one
+	 * @param source An optional Mesh from which geometry is shared, cloned.
+	 * @param doNotCloneChildren When cloning, skip cloning child meshes of source, default False.
+	 *                  When false, achieved by calling a clone(), also passing False.
+	 *                  This will make creation of children, recursive.
+	 * @param clonePhysicsImpostor When cloning, include cloning mesh physics impostor, default True.
+	 */
+	public constructor(
+		name: string,
+		scene: Scene,
+		parent?: Node | null,
+		source?: Mesh | null,
+		doNotCloneChildren?: boolean,
+		clonePhysicsImpostor?: boolean,
+	) {
+		super(name, scene, parent, source, doNotCloneChildren, clonePhysicsImpostor);
 
-    	this.id = Tools.RandomId();
-    	this.uniqueId = UniqueNumber.Get();
-    }
+		this.id = Tools.RandomId();
+		this.uniqueId = UniqueNumber.Get();
+	}
 
-    public async setType(type: CollisionMeshType, sourceMesh: AbstractMesh): Promise<void> {
-    	sourceMesh.refreshBoundingInfo({
-    		applyMorph: true,
-    		applySkeleton: true,
-    	});
+	public async setType(type: CollisionMeshType, sourceMesh: AbstractMesh): Promise<void> {
+		sourceMesh.refreshBoundingInfo({
+			applyMorph: true,
+			applySkeleton: true,
+		});
 
-    	this.type = type;
+		this.type = type;
 
-    	const bb = sourceMesh.getBoundingInfo();
+		const bb = sourceMesh.getBoundingInfo();
 
-    	switch (type) {
-    	case "cube":
-    		this._createCubeCollisionMesh(sourceMesh, bb);
-    		break;
+		switch (type) {
+			case "cube":
+				this._createCubeCollisionMesh(sourceMesh, bb);
+				break;
 
-    	case "sphere":
-    		this._createSphereCollisionMesh(sourceMesh, bb);
-    		break;
+			case "sphere":
+				this._createSphereCollisionMesh(sourceMesh, bb);
+				break;
 
-    	case "capsule":
-    		this._createCapsuleCollisionMesh(sourceMesh, bb);
-    		break;
+			case "capsule":
+				this._createCapsuleCollisionMesh(sourceMesh, bb);
+				break;
 
-    	case "lod":
-    		if (isMesh(sourceMesh)) {
-    			await this._createLodCollisionMesh(sourceMesh);
-    		}
-    		break;
-    	}
+			case "lod":
+				if (isMesh(sourceMesh)) {
+					await this._createLodCollisionMesh(sourceMesh);
+				}
+				break;
+		}
 
-    	if (this.geometry) {
-    		this.material = this._createMaterial();
+		if (this.geometry) {
+			this.material = this._createMaterial();
 
-    		// Manage instances
-    		if (isMesh(sourceMesh)) {
-    			this.updateInstances(sourceMesh, bb);
-    		}
-    	}
-    }
+			// Manage instances
+			if (isMesh(sourceMesh)) {
+				this.updateInstances(sourceMesh, bb);
+			}
+		}
+	}
 
-    public updateInstances(sourceMesh: Mesh, boundingInfo?: BoundingInfo): void {
-    	if (!boundingInfo) {
-    		sourceMesh.refreshBoundingInfo({
-    			applyMorph: true,
-    			applySkeleton: true,
-    		});
+	public updateInstances(sourceMesh: Mesh, boundingInfo?: BoundingInfo): void {
+		if (!boundingInfo) {
+			sourceMesh.refreshBoundingInfo({
+				applyMorph: true,
+				applySkeleton: true,
+			});
 
-    		boundingInfo = sourceMesh.getBoundingInfo();
-    	}
+			boundingInfo = sourceMesh.getBoundingInfo();
+		}
 
-    	// Manage instances
-    	while (this.instances.length) {
-    		this.instances[0].dispose(false, false);
-    	}
+		// Manage instances
+		while (this.instances.length) {
+			this.instances[0].dispose(false, false);
+		}
 
-    	if (isMesh(sourceMesh)) {
-    		sourceMesh.instances.forEach((instance) => {
-    			const collisionInstance = this.createInstance(this.name);
-    			collisionInstance.parent = instance;
-    			collisionInstance.id = Tools.RandomId();
-    			collisionInstance.uniqueId = UniqueNumber.Get();
-    			collisionInstance.isVisible = false;
+		if (isMesh(sourceMesh)) {
+			sourceMesh.instances.forEach((instance) => {
+				const collisionInstance = this.createInstance(this.name);
+				collisionInstance.parent = instance;
+				collisionInstance.id = Tools.RandomId();
+				collisionInstance.uniqueId = UniqueNumber.Get();
+				collisionInstance.isVisible = false;
 
-    			switch (this.type) {
-    			case "cube":
-    				collisionInstance.position.copyFrom(boundingInfo.boundingBox.center);
-    				collisionInstance.scaling.copyFrom(boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingBox.minimum));
-    				break;
+				switch (this.type) {
+					case "cube":
+						collisionInstance.position.copyFrom(boundingInfo.boundingBox.center);
+						collisionInstance.scaling.copyFrom(boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingBox.minimum));
+						break;
 
-    			case "sphere":
-    				collisionInstance.position.copyFrom(boundingInfo.boundingSphere.center);
-    				collisionInstance.scaling.copyFrom(boundingInfo.boundingSphere.maximum.subtract(boundingInfo.boundingSphere.minimum));
-    				break;
+					case "sphere":
+						collisionInstance.position.copyFrom(boundingInfo.boundingSphere.center);
+						collisionInstance.scaling.copyFrom(boundingInfo.boundingSphere.maximum.subtract(boundingInfo.boundingSphere.minimum));
+						break;
 
-    			case "capsule":
-    				collisionInstance.position.copyFrom(boundingInfo.boundingSphere.center);
-    				break;
-    			}
-    		});
-    	}
-    }
+					case "capsule":
+						collisionInstance.position.copyFrom(boundingInfo.boundingSphere.center);
+						break;
+				}
+			});
+		}
+	}
 
-    private static _DebugMaterial: PBRMaterial | null = null;
+	private static _debugMaterial: PBRMaterial | null = null;
 
-    private _createMaterial(): PBRMaterial {
-    	if (CollisionMesh._DebugMaterial) {
-    		return CollisionMesh._DebugMaterial;
-    	}
+	private _createMaterial(): PBRMaterial {
+		if (CollisionMesh._debugMaterial) {
+			return CollisionMesh._debugMaterial;
+		}
 
-    	const material = new PBRMaterial(this.name, this._scene);
-    	material.unlit = true;
-    	material.id = Tools.RandomId();
-    	material.uniqueId = UniqueNumber.Get();
+		const material = new PBRMaterial(this.name, this._scene);
+		material.unlit = true;
+		material.id = Tools.RandomId();
+		material.uniqueId = UniqueNumber.Get();
 
-    	MeshDebugPluginMaterial.PrepareMeshForTrianglesAndVerticesMode(this);
-    	new MeshDebugPluginMaterial(material, {
-    		wireframeThickness: 1,
-    		mode: BABYLON.MeshDebugMode.TRIANGLES,
-    		wireframeTrianglesColor: new BABYLON.Color3(0, 0, 0),
-    	});
+		MeshDebugPluginMaterial.PrepareMeshForTrianglesAndVerticesMode(this);
+		new MeshDebugPluginMaterial(material, {
+			wireframeThickness: 1,
+			mode: BABYLON.MeshDebugMode.TRIANGLES,
+			wireframeTrianglesColor: new BABYLON.Color3(0, 0, 0),
+		});
 
-    	CollisionMesh._DebugMaterial = material;
+		CollisionMesh._debugMaterial = material;
 
-    	return material;
-    }
+		return material;
+	}
 
-    private _createCubeCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
-    	const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateBoxVertexData({
-    		size: 1,
-    	}));
+	private _createCubeCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
+		const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateBoxVertexData({
+			size: 1,
+		}));
 
-    	geometry.uniqueId = UniqueNumber.Get();
-    	geometry.applyToMesh(this);
-    	this.position.copyFrom(boundingInfo.boundingBox.center);
-    	this.scaling.copyFrom(boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingBox.minimum));
-    }
+		geometry.uniqueId = UniqueNumber.Get();
+		geometry.applyToMesh(this);
+		this.position.copyFrom(boundingInfo.boundingBox.center);
+		this.scaling.copyFrom(boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingBox.minimum));
+	}
 
-    private _createSphereCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
-    	const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateSphereVertexData({
-    		diameter: 1,
-    		segments: 16,
-    	}));
+	private _createSphereCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
+		const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateSphereVertexData({
+			diameter: 1,
+			segments: 16,
+		}));
 
-    	geometry.uniqueId = UniqueNumber.Get();
-    	geometry.applyToMesh(this);
-    	this.position.copyFrom(boundingInfo.boundingSphere.center);
-    	this.scaling.copyFrom(boundingInfo.boundingSphere.maximum.subtract(boundingInfo.boundingSphere.minimum));
-    }
+		geometry.uniqueId = UniqueNumber.Get();
+		geometry.applyToMesh(this);
+		this.position.copyFrom(boundingInfo.boundingSphere.center);
+		this.scaling.copyFrom(boundingInfo.boundingSphere.maximum.subtract(boundingInfo.boundingSphere.minimum));
+	}
 
-    private _createCapsuleCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
-    	const size = boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingSphere.minimum);
+	private _createCapsuleCollisionMesh(sourceMesh: AbstractMesh, boundingInfo: BoundingInfo): void {
+		const size = boundingInfo.boundingBox.maximum.subtract(boundingInfo.boundingSphere.minimum);
 
-    	const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateCapsuleVertexData({
-    		height: Math.abs(size.y),
-    		radius: boundingInfo.boundingSphere.radius,
+		const geometry = new Geometry(Tools.RandomId(), sourceMesh.getScene(), CreateCapsuleVertexData({
+			height: Math.abs(size.y),
+			radius: boundingInfo.boundingSphere.radius,
 
-    		subdivisions: 16,
-    		tessellation: 16,
-    		capSubdivisions: 12,
-    		topCapSubdivisions: 12,
-    		orientation: Vector3.Up(),
-    	}));
+			subdivisions: 16,
+			tessellation: 16,
+			capSubdivisions: 12,
+			topCapSubdivisions: 12,
+			orientation: Vector3.Up(),
+		}));
 
-    	geometry.uniqueId = UniqueNumber.Get();
-    	geometry.applyToMesh(this);
-    	this.position.copyFrom(boundingInfo.boundingSphere.center);
-    }
+		geometry.uniqueId = UniqueNumber.Get();
+		geometry.applyToMesh(this);
+		this.position.copyFrom(boundingInfo.boundingSphere.center);
+	}
 
-    private _createLodCollisionMesh(sourceMesh: Mesh): Promise<void> {
-    	return new Promise<void>((resolve) => {
-    		const decimator = new QuadraticErrorSimplification(sourceMesh);
+	private _createLodCollisionMesh(sourceMesh: Mesh): Promise<void> {
+		return new Promise<void>((resolve) => {
+			const decimator = new QuadraticErrorSimplification(sourceMesh);
 
-    		decimator.simplify({ distance: 100, quality: 0.01, optimizeMesh: true }, (sm) => {
-    			const geometry = sm.geometry;
-    			if (geometry) {
-    				geometry.id = Tools.RandomId();
-    				geometry.uniqueId = UniqueNumber.Get();
-    				geometry.applyToMesh(this);
-    			}
+			decimator.simplify({ distance: 100, quality: 0.01, optimizeMesh: true }, (sm) => {
+				const geometry = sm.geometry;
+				if (geometry) {
+					geometry.id = Tools.RandomId();
+					geometry.uniqueId = UniqueNumber.Get();
+					geometry.applyToMesh(this);
+				}
 
-    			sm.dispose(false, false);
+				sm.dispose(false, false);
 
-    			resolve();
-    		});
-    	});
-    }
+				resolve();
+			});
+		});
+	}
 
-    /**
-      * Gets the current object class name.
-      * @return the class name
-      */
-    public getClassName(): string {
-    	return "CollisionMesh";
-    }
+	/**
+	  * Gets the current object class name.
+	  * @return the class name
+	  */
+	public getClassName(): string {
+		return "CollisionMesh";
+	}
 
-    /**
-     * Creates a new collision mesh based on the given source mesh parameters.
-     * @param sourceMesh defines the source mesh to copy in order to transform as collision mesh.
-     * @param type defines the collision type for the mesh.
-     */
-    public static CreateFromSourceMesh(sourceMesh: Mesh, type: CollisionMeshType): CollisionMesh {
-    	const geometry = sourceMesh.geometry;
-    	geometry?.releaseForMesh(sourceMesh);
+	/**
+	 * Creates a new collision mesh based on the given source mesh parameters.
+	 * @param sourceMesh defines the source mesh to copy in order to transform as collision mesh.
+	 * @param type defines the collision type for the mesh.
+	 */
+	public static CreateFromSourceMesh(sourceMesh: Mesh, type: CollisionMeshType): CollisionMesh {
+		const geometry = sourceMesh.geometry;
+		geometry?.releaseForMesh(sourceMesh);
 
-    	const collisionMesh = new CollisionMesh(sourceMesh.name, sourceMesh.getScene(), sourceMesh.parent, sourceMesh, true, false);
-    	collisionMesh.type = type;
-    	collisionMesh.id = sourceMesh.id;
-    	collisionMesh.uniqueId = sourceMesh.uniqueId;
-    	collisionMesh.metadata = sourceMesh.metadata;
+		const collisionMesh = new CollisionMesh(sourceMesh.name, sourceMesh.getScene(), sourceMesh.parent, sourceMesh, true, false);
+		collisionMesh.type = type;
+		collisionMesh.id = sourceMesh.id;
+		collisionMesh.uniqueId = sourceMesh.uniqueId;
+		collisionMesh.metadata = sourceMesh.metadata;
 
-    	collisionMesh.position = sourceMesh.position;
-    	collisionMesh.rotation = sourceMesh.rotation;
-    	collisionMesh.rotationQuaternion = sourceMesh.rotationQuaternion;
-    	collisionMesh.scaling = sourceMesh.scaling;
-    	collisionMesh.isVisible = false;
+		collisionMesh.position = sourceMesh.position;
+		collisionMesh.rotation = sourceMesh.rotation;
+		collisionMesh.rotationQuaternion = sourceMesh.rotationQuaternion;
+		collisionMesh.scaling = sourceMesh.scaling;
+		collisionMesh.isVisible = false;
 
-    	collisionMesh.metadata ??= {};
-    	collisionMesh.metadata.isCollisionMesh = true;
+		collisionMesh.metadata ??= {};
+		collisionMesh.metadata.isCollisionMesh = true;
 
-    	setTimeout(() => {
-    		geometry?.applyToMesh(collisionMesh);
-    	}, 0);
+		setTimeout(() => {
+			geometry?.applyToMesh(collisionMesh);
+		}, 0);
 
-    	collisionMesh.material = collisionMesh._createMaterial();
+		collisionMesh.material = collisionMesh._createMaterial();
 
-    	sourceMesh.instances.forEach((instance) => {
-    		const collisionInstance = collisionMesh.createInstance(instance.name);
-    		collisionInstance.id = instance.id;
-    		collisionInstance.uniqueId = instance.uniqueId;
-    		collisionInstance.metadata = instance.metadata;
+		sourceMesh.instances.forEach((instance) => {
+			const collisionInstance = collisionMesh.createInstance(instance.name);
+			collisionInstance.id = instance.id;
+			collisionInstance.uniqueId = instance.uniqueId;
+			collisionInstance.metadata = instance.metadata;
 
-    		collisionInstance.position = instance.position;
-    		collisionInstance.rotation = instance.rotation;
-    		collisionInstance.rotationQuaternion = instance.rotationQuaternion;
-    		collisionInstance.scaling = instance.scaling;
-    		collisionInstance.isVisible = false;
+			collisionInstance.position = instance.position;
+			collisionInstance.rotation = instance.rotation;
+			collisionInstance.rotationQuaternion = instance.rotationQuaternion;
+			collisionInstance.scaling = instance.scaling;
+			collisionInstance.isVisible = false;
 
-    		collisionInstance.metadata ??= {};
-    		collisionInstance.metadata.isCollisionMesh = true;
-    	});
+			collisionInstance.metadata ??= {};
+			collisionInstance.metadata.isCollisionMesh = true;
+		});
 
-    	return collisionMesh;
-    }
+		return collisionMesh;
+	}
 }
 
 Node.AddNodeConstructor("CollisionMesh", (name, scene) => {

--- a/editor/src/project/add/material.ts
+++ b/editor/src/project/add/material.ts
@@ -1,0 +1,36 @@
+import { Scene, Tools, PBRMaterial, StandardMaterial, NodeMaterial } from "babylonjs";
+import { SkyMaterial } from "babylonjs-materials";
+import { UniqueNumber } from "../../tools/tools";
+
+export function addPBRMaterial(scene: Scene) {
+	const material = new PBRMaterial("New PBR Material", scene);
+	material.id = Tools.RandomId();
+	material.uniqueId = UniqueNumber.Get();
+
+	return material;
+}
+
+export function addStandardMaterial(scene: Scene) {
+	const material = new StandardMaterial("New Standard Material", scene);
+	material.id = Tools.RandomId();
+	material.uniqueId = UniqueNumber.Get();
+
+	return material;
+}
+
+export function addNodeMaterial(scene: Scene) {   
+	const material = new NodeMaterial("New Node Material", scene);
+	material.id = Tools.RandomId();
+	material.uniqueId = UniqueNumber.Get();
+	material.setToDefault();
+
+	return material;
+}
+
+export function addSkyMaterial(scene: Scene) {
+	const material = new SkyMaterial("New Sky Material", scene);
+	material.id = Tools.RandomId();
+	material.uniqueId = UniqueNumber.Get();
+
+	return material;
+}

--- a/editor/src/tools/animation/tween.ts
+++ b/editor/src/tools/animation/tween.ts
@@ -10,40 +10,40 @@ import {
 } from "./tools";
 
 export interface ITweenEasingConfiguration {
-    mode: number;
-    type: EasingFunction;
+	mode: number;
+	type: EasingFunction;
 }
 
 export interface ITweenPropertyConfiguration {
-    from: any;
-    to: any;
+	from: any;
+	to: any;
 
-    duration?: number;
-    delay?: number;
+	duration?: number;
+	delay?: number;
 
-    easing?: ITweenEasingConfiguration;
+	easing?: ITweenEasingConfiguration;
 
-    value: any;
+	value: any;
 }
 
 export interface ITweenConfiguration {
-    scene?: Scene;
-    delay?: number;
-    easing?: ITweenEasingConfiguration;
+	scene?: Scene;
+	delay?: number;
+	easing?: ITweenEasingConfiguration;
 
-    loop?: boolean;
+	loop?: boolean;
 
-    properties?: {
-        [propertyPath: string]: ITweenPropertyConfiguration | any;
-    };
+	properties?: {
+		[propertyPath: string]: ITweenPropertyConfiguration | any;
+	};
 
-    onStart?: () => void;
-    onUpdate?: () => void;
-    onComplete?: () => void;
+	onStart?: () => void;
+	onUpdate?: () => void;
+	onComplete?: () => void;
 
-    [propertyPath: string]: ITweenPropertyConfiguration | any;
+	[propertyPath: string]: ITweenPropertyConfiguration | any;
 
-    killAllTweensOfTarget?: boolean;
+	killAllTweensOfTarget?: boolean;
 }
 
 const reservedProperties = [
@@ -64,14 +64,14 @@ const reservedProperties = [
 
 export class Tween {
 	/**
-     * Defines the reference to the promise resolved on the tween ended.
-     */
+	 * Defines the reference to the promise resolved on the tween ended.
+	 */
 	public promise: Promise<void[]>;
 
 	/**
-     * Constructor.
-     * @param animatable defines the reference to the animatable that is being played.
-     */
+	 * Constructor.
+	 * @param animatable defines the reference to the animatable that is being played.
+	 */
 	public constructor(public animatables: Animatable[]) {
 		this.promise = Promise.all(
 			animatables.map((a) => {
@@ -83,32 +83,32 @@ export class Tween {
 	}
 
 	/**
-     * Pauses the tween animation.
-     */
+	 * Pauses the tween animation.
+	 */
 	public pause(): void {
 		this.animatables.forEach((a) => a.pause());
 	}
 
 	/**
-     * Restarts the animation.
-     */
+	 * Restarts the animation.
+	 */
 	public reset(): void {
 		this.animatables.forEach((a) => a.reset());
 	}
 
 	/**
-     * Stops the tween animation. Resolves the promise.
-     */
+	 * Stops the tween animation. Resolves the promise.
+	 */
 	public stop(): void {
 		this.animatables.forEach((a) => a.stop());
 	}
 
 	/**
-     * Attaches callbacks for the resolution and/or rejection of the Promise.
-     * @param onfulfilled The callback to execute when the Promise is resolved.
-     * @param onrejected The callback to execute when the Promise is rejected.
-     * @returns A Promise for the completion of which ever callback is executed.
-     */
+	 * Attaches callbacks for the resolution and/or rejection of the Promise.
+	 * @param onfulfilled The callback to execute when the Promise is resolved.
+	 * @param onrejected The callback to execute when the Promise is rejected.
+	 * @returns A Promise for the completion of which ever callback is executed.
+	 */
 	public then<T1 = void, T2 = never>(
 		onfulfilled?: ((value: any) => T1 | PromiseLike<T1>) | undefined | null,
 		onrejected?: ((reason: any) => T2 | PromiseLike<T2>) | undefined | null
@@ -117,21 +117,21 @@ export class Tween {
 	}
 
 	/**
-     * Defines the reference to the scene where to play the tweens.
-     */
+	 * Defines the reference to the scene where to play the tweens.
+	 */
 	public static Scene: Nullable<Scene> = null;
 
 	/**
-     * Defines the default easing function used when playing tweens.
-     */
+	 * Defines the default easing function used when playing tweens.
+	 */
 	public static DefaultEasing: Nullable<ITweenEasingConfiguration> = null;
 
 	/**
-     * Kills (stops) all the tweens that animate to given target.
-     * @param target defines the reference to the target to kill all its attached tweens.
-     * @returns true if at least one tween has been killed.
-     */
-	public static KillTweensOf<T>(target: T | T[]): boolean {
+	 * Kills (stops) all the tweens that animate to given target.
+	 * @param target defines the reference to the target to kill all its attached tweens.
+	 * @returns true if at least one tween has been killed.
+	 */
+	public static killTweensOf<T>(target: T | T[]): boolean {
 		target = Array.isArray(target) ? target : [target];
 
 		const result = target.map((t) => {
@@ -149,7 +149,7 @@ export class Tween {
 		return result.includes(true);
 	}
 
-	public static KillAllTweens(): void {
+	public static killAllTweens(): void {
 		tweensMap.forEach((v) => {
 			v.forEach((t) => t.stop());
 		});
@@ -158,18 +158,18 @@ export class Tween {
 	}
 
 	/**
-     * Creates a new tween reference to anmate CSS properties of the given HTML element for the given duration.
-     * @param target defines the target HTML object to animate its properties.
-     * @param duration defines the duration of the animation(s) expressed in seconds.
-     * @param properties defines the dictionary of all animated properties.
-     * @returns a reference to a tween.
-     */
-	public static CreateForCSS(
+	 * Creates a new tween reference to anmate CSS properties of the given HTML element for the given duration.
+	 * @param target defines the target HTML object to animate its properties.
+	 * @param duration defines the duration of the animation(s) expressed in seconds.
+	 * @param properties defines the dictionary of all animated properties.
+	 * @returns a reference to a tween.
+	 */
+	public static createForCSS(
 		target: HTMLElement,
 		duration: number,
 		options: ITweenConfiguration
 	): Tween {
-		this._ConfigureOptions(options);
+		this._configureOptions(options);
 
 		const keys = Object.keys(options.properties!);
 		const values: { [propertyPath: string]: number; } = {};
@@ -178,7 +178,7 @@ export class Tween {
 			values[k] = options.properties![k].from ?? (parseFloat(target.style[k]) || 0);
 		});
 
-		return this.Create<any>(values, duration, {
+		return this.create<any>(values, duration, {
 			...options,
 			onUpdate: () => {
 				keys.forEach((k: any) => {
@@ -188,7 +188,7 @@ export class Tween {
 		});
 	}
 
-	private static _ConfigureOptions(options: ITweenConfiguration): void {
+	private static _configureOptions(options: ITweenConfiguration): void {
 		options.properties ??= {};
 
 		Object.keys(options).forEach((k) => {
@@ -196,18 +196,18 @@ export class Tween {
 				return;
 			}
 
-            options.properties![k] = options[k];
+			options.properties![k] = options[k];
 		});
 	}
 
 	/**
-     * Creates a new tween reference to animate properties of the given target for the given duration.
-     * @param target defines the target object to animate its properties.
-     * @param duration defines the duration of the animation(s) expressed in seconds.
-     * @param options defines the options the tween (easing, delay, etc.).
-     * @returns a reference to a tween.
-     */
-	public static Create<T>(
+	 * Creates a new tween reference to animate properties of the given target for the given duration.
+	 * @param target defines the target object to animate its properties.
+	 * @param duration defines the duration of the animation(s) expressed in seconds.
+	 * @param options defines the options the tween (easing, delay, etc.).
+	 * @returns a reference to a tween.
+	 */
+	public static create<T>(
 		target: Nullable<T> | Nullable<T>[],
 		duration: number,
 		options: ITweenConfiguration
@@ -217,10 +217,10 @@ export class Tween {
 		}
 
 		if (options.killAllTweensOfTarget) {
-			this.KillTweensOf(target);
+			this.killTweensOf(target);
 		}
 
-		this._ConfigureOptions(options);
+		this._configureOptions(options);
 
 		target = Array.isArray(target) ? target : [target];
 
@@ -247,7 +247,7 @@ export class Tween {
 				}
 
 				const targetProperty = k.split(".").pop()!;
-				const effectiveTarget = this._GetEffectiveTarget(t, k);
+				const effectiveTarget = this._getEffectiveTarget(t, k);
 				const animatedProperty = effectiveTarget?.[targetProperty];
 
 				if ((animatedProperty ?? null) === null) {
@@ -296,8 +296,8 @@ export class Tween {
 					k,
 					k,
 					60,
-                    getAnimationTypeForObject(animatedProperty)!,
-                    Animation.ANIMATIONLOOPMODE_RELATIVE
+					getAnimationTypeForObject(animatedProperty)!,
+					Animation.ANIMATIONLOOPMODE_RELATIVE
 				);
 				a.setKeys(keys);
 
@@ -356,9 +356,9 @@ export class Tween {
 	}
 
 	/**
-     * Given a path to a property, return the effective property by deconstructing the path.
-     */
-	private static _GetEffectiveTarget(target: any, propertyPath: string): any {
+	 * Given a path to a property, return the effective property by deconstructing the path.
+	 */
+	private static _getEffectiveTarget(target: any, propertyPath: string): any {
 		const properties = propertyPath.split(".");
 
 		for (let index = 0; index < properties.length - 1; index++) {

--- a/editor/src/tools/mesh/augmentations.ts
+++ b/editor/src/tools/mesh/augmentations.ts
@@ -3,6 +3,7 @@ import { PhysicsAggregate } from "babylonjs";
 export { AbstractMesh } from "babylonjs";
 
 declare module "babylonjs" {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     export interface AbstractMesh {
         physicsAggregate?: PhysicsAggregate | null;
     }

--- a/editor/src/tools/sound/augmentations.ts
+++ b/editor/src/tools/sound/augmentations.ts
@@ -1,6 +1,7 @@
 export { Sound } from "babylonjs";
 
 declare module "babylonjs" {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     export interface Sound {
         id: string;
         uniqueId: number;

--- a/editor/src/tools/tools.ts
+++ b/editor/src/tools/tools.ts
@@ -35,16 +35,16 @@ export async function waitUntil(predicate: () => any): Promise<void> {
  * @example myNode.uniqueId = UniqueNumber.Get();
  */
 export class UniqueNumber {
-	private static _Previous = 0;
+	private static _previous = 0;
 
 	public static Get(): number {
 		let date = Date.now();
 
 		// If created at same millisecond as previous
-		if (date <= UniqueNumber._Previous) {
-			date = ++UniqueNumber._Previous;
+		if (date <= UniqueNumber._previous) {
+			date = ++UniqueNumber._previous;
 		} else {
-			UniqueNumber._Previous = date;
+			UniqueNumber._previous = date;
 		}
 
 		return date;

--- a/eslint.config.mjs
+++ b/eslint.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "eslint/config";
 import typeScriptParser from "@typescript-eslint/parser";
+import typeScriptPlugin from "@typescript-eslint/eslint-plugin";
 
 export default defineConfig([
     {
@@ -14,6 +15,9 @@ export default defineConfig([
         languageOptions: {
             ecmaVersion: "latest",
             parser: typeScriptParser,
+        },
+        plugins: {
+            "@typescript-eslint": typeScriptPlugin,
         },
         rules: {
             // Recommended
@@ -78,6 +82,30 @@ export default defineConfig([
             "no-useless-backreference": "error",
             "use-isnan": "error",
             "valid-typeof": "error",
+
+            "@typescript-eslint/naming-convention": ["error",
+                {
+                    "selector": "enumMember",
+                    "format": ["PascalCase"],
+                },
+                {
+                    "selector": "function",
+                    "format": ["camelCase", "PascalCase"],
+                    "leadingUnderscore": "allow"
+                },
+                {
+                    "selector": "interface",
+                    "format": ["PascalCase"],
+                    "prefix": ["I"],
+                    "leadingUnderscore": "allow",
+                },
+                {
+                    "selector": "memberLike",
+                    "modifiers": ["private"],
+                    "format": ["camelCase"],
+                    "leadingUnderscore": "require"
+                }
+            ],
 
             // Suggestions
             "block-scoped-var": "error",

--- a/package.json
+++ b/package.json
@@ -49,7 +49,8 @@
     "readme": "https://github.com/BabylonJS/Editor/blob/master/README.md",
     "license": "(Apache-2.0)",
     "devDependencies": {
-        "@typescript-eslint/parser": "8.35.0",
+        "@typescript-eslint/eslint-plugin": "8.35.1",
+        "@typescript-eslint/parser": "8.35.1",
         "concurrently": "9.2.0",
         "cross-env": "7.0.3",
         "dotenv": "16.4.5",

--- a/quixel/src/tools/textureMerger.ts
+++ b/quixel/src/tools/textureMerger.ts
@@ -6,32 +6,32 @@ import { Tools as BabylonTools, Texture, ISize } from "babylonjs";
 import { WorkerTools } from "./workers";
 
 export interface IMergedColor {
-    /**
-     * Defines the value of the red channel for the pixel.
-     */
-    r: number;
-    /**
-     * Defines the value of the green channel for the pixel.
-     */
-    g: number;
-    /**
-     * Defines the value of the blue channel for the pixel.
-     */
-    b: number;
-    /**
-     * Defines the value of the alpha channel for the pixel.
-     */
-    a: number;
+	/**
+	 * Defines the value of the red channel for the pixel.
+	 */
+	r: number;
+	/**
+	 * Defines the value of the green channel for the pixel.
+	 */
+	g: number;
+	/**
+	 * Defines the value of the blue channel for the pixel.
+	 */
+	b: number;
+	/**
+	 * Defines the value of the alpha channel for the pixel.
+	 */
+	a: number;
 }
 
 export class TextureUtils {
 	/**
-     * Merges the two given textures to the desized format.
-     * @param a defines the reference to the first texture.
-     * @param b defines the reference to the second texture.
-     * @param rootFolder defines the root folder where to write the texture.
-     * @param callback defines the callback called for each pixel that returns the final merged color.
-     */
+	 * Merges the two given textures to the desized format.
+	 * @param a defines the reference to the first texture.
+	 * @param b defines the reference to the second texture.
+	 * @param rootFolder defines the root folder where to write the texture.
+	 * @param callback defines the callback called for each pixel that returns the final merged color.
+	 */
 	public static async MergeTextures(a: Texture, b: Texture, rootFolder: string, callback: (color1: IMergedColor, color2: IMergedColor) => IMergedColor): Promise<string | null> {
 		const aSize = a.getSize();
 		const bSize = b.getSize();
@@ -59,7 +59,7 @@ export class TextureUtils {
 
 		worker.terminate();
 
-		const blob = await this._ConvertPixelsToBlobImage(aSize, new Uint8ClampedArray(result));
+		const blob = await this._convertPixelsToBlobImage(aSize, new Uint8ClampedArray(result));
 		if (!blob) {
 			return null;
 		}
@@ -73,9 +73,9 @@ export class TextureUtils {
 	}
 
 	/**
-     * Converts the given pixels to a readable blob image.
-     */
-	private static async _ConvertPixelsToBlobImage(size: ISize, pixels: Uint8ClampedArray): Promise<Blob | null> {
+	 * Converts the given pixels to a readable blob image.
+	 */
+	private static async _convertPixelsToBlobImage(size: ISize, pixels: Uint8ClampedArray): Promise<Blob | null> {
 		// Base canvas
 		const canvas = document.createElement("canvas");
 		canvas.width = size.width;
@@ -97,7 +97,7 @@ export class TextureUtils {
 		finalContext.transform(1, 0, 0, -1, 0, canvas.height);
 		finalContext.drawImage(canvas, 0, 0);
 
-		const blob = await this._CanvasToBlob(finalCanvas);
+		const blob = await this._canvasToBlob(finalCanvas);
 
 		context.restore();
 		finalContext.restore();
@@ -108,9 +108,9 @@ export class TextureUtils {
 	}
 
 	/**
-     * Converts the given canvas data to blob.
-     */
-	private static async _CanvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
+	 * Converts the given canvas data to blob.
+	 */
+	private static async _canvasToBlob(canvas: HTMLCanvasElement): Promise<Blob | null> {
 		return new Promise<Blob | null>((resolve) => {
 			BabylonTools.ToBlob(canvas, b => resolve(b));
 		});

--- a/tools/src/decorators/inspector.ts
+++ b/tools/src/decorators/inspector.ts
@@ -211,7 +211,7 @@ export type VisibleInInspectorDecoratorColor4Configuration = VisibleInInspectorD
 export function visibleAsEntity(
 	entityType: VisibleAsEntityType,
 	label?: string,
-	configuration?: Omit<VisibleInInspectorDecoratorEntityConfiguration, "type">,
+	configuration?: Omit<VisibleInInspectorDecoratorEntityConfiguration, "type" | "entityType">,
 ) {
 	return function (target: any, propertyKey: string | Symbol) {
 		const ctor = target.constructor as ISceneDecoratorData;

--- a/tools/src/loading/loader.ts
+++ b/tools/src/loading/loader.ts
@@ -47,6 +47,7 @@ export type SceneLoaderOptions = {
 };
 
 declare module "@babylonjs/core/scene" {
+	// eslint-disable-next-line @typescript-eslint/naming-convention
 	interface Scene {
 		loadingQuality: SceneLoaderQualitySelector;
 	}

--- a/tools/src/tools/mesh.ts
+++ b/tools/src/tools/mesh.ts
@@ -1,6 +1,7 @@
 import { PhysicsAggregate } from "@babylonjs/core/Physics/v2/physicsAggregate";
 
 declare module "@babylonjs/core/Meshes/abstractMesh" {
+    // eslint-disable-next-line @typescript-eslint/naming-convention
     export interface AbstractMesh {
         physicsAggregate?: PhysicsAggregate | null;
     }

--- a/tools/src/tools/sound.ts
+++ b/tools/src/tools/sound.ts
@@ -1,10 +1,11 @@
 import { Scene } from "@babylonjs/core/scene";
 
 declare module "@babylonjs/core/Audio/sound" {
-    export interface Sound {
-        id: string;
-        uniqueId: number;
-    }
+	// eslint-disable-next-line @typescript-eslint/naming-convention
+	export interface Sound {
+		id: string;
+		uniqueId: number;
+	}
 }
 
 /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -1471,7 +1471,14 @@
   dependencies:
     eslint-visitor-keys "^3.3.0"
 
-"@eslint-community/regexpp@^4.12.1":
+"@eslint-community/eslint-utils@^4.7.0":
+  version "4.7.0"
+  resolved "https://registry.yarnpkg.com/@eslint-community/eslint-utils/-/eslint-utils-4.7.0.tgz#607084630c6c033992a082de6e6fbc1a8b52175a"
+  integrity sha512-dyybb3AcajC7uha6CvhdVRJqaKyn7w2YKqKyAN37NKYgZT36w+iRb0Dymmc5qEJ549c/S31cMMSFd75bteCpCw==
+  dependencies:
+    eslint-visitor-keys "^3.4.3"
+
+"@eslint-community/regexpp@^4.10.0", "@eslint-community/regexpp@^4.12.1":
   version "4.12.1"
   resolved "https://registry.yarnpkg.com/@eslint-community/regexpp/-/regexpp-4.12.1.tgz#cfc6cffe39df390a3841cde2abccf92eaa7ae0e0"
   integrity sha512-CCZCDJuduB9OUkFkY2IgppNZMi2lBQgD2qzwXkEia16cge2pijY/aXi96CJMquDMn3nJdlPV1A5KrJEXwfLNzQ==
@@ -3004,15 +3011,30 @@
   dependencies:
     "@types/node" "*"
 
-"@typescript-eslint/parser@8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.35.0.tgz#20a0e17778a329a6072722f5ac418d4376b767d2"
-  integrity sha512-6sMvZePQrnZH2/cJkwRpkT7DxoAWh+g6+GFRK6bV3YQo7ogi3SX5rgF6099r5Q53Ma5qeT7LGmOmuIutF4t3lA==
+"@typescript-eslint/eslint-plugin@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/eslint-plugin/-/eslint-plugin-8.35.1.tgz#06b1129fe26d6532abd58fb2b3fe9810bd016935"
+  integrity sha512-9XNTlo7P7RJxbVeICaIIIEipqxLKguyh+3UbXuT2XQuFp6d8VOeDEGuz5IiX0dgZo8CiI6aOFLg4e8cF71SFVg==
   dependencies:
-    "@typescript-eslint/scope-manager" "8.35.0"
-    "@typescript-eslint/types" "8.35.0"
-    "@typescript-eslint/typescript-estree" "8.35.0"
-    "@typescript-eslint/visitor-keys" "8.35.0"
+    "@eslint-community/regexpp" "^4.10.0"
+    "@typescript-eslint/scope-manager" "8.35.1"
+    "@typescript-eslint/type-utils" "8.35.1"
+    "@typescript-eslint/utils" "8.35.1"
+    "@typescript-eslint/visitor-keys" "8.35.1"
+    graphemer "^1.4.0"
+    ignore "^7.0.0"
+    natural-compare "^1.4.0"
+    ts-api-utils "^2.1.0"
+
+"@typescript-eslint/parser@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/parser/-/parser-8.35.1.tgz#787312e80f0f337d85f4c2a569411c469e852d44"
+  integrity sha512-3MyiDfrfLeK06bi/g9DqJxP5pV74LNv4rFTyvGDmT3x2p1yp1lOd+qYZfiRPIOf/oON+WRZR5wxxuF85qOar+w==
+  dependencies:
+    "@typescript-eslint/scope-manager" "8.35.1"
+    "@typescript-eslint/types" "8.35.1"
+    "@typescript-eslint/typescript-estree" "8.35.1"
+    "@typescript-eslint/visitor-keys" "8.35.1"
     debug "^4.3.4"
 
 "@typescript-eslint/parser@^5.4.2 || ^6.0.0":
@@ -3026,13 +3048,13 @@
     "@typescript-eslint/visitor-keys" "6.18.0"
     debug "^4.3.4"
 
-"@typescript-eslint/project-service@8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.35.0.tgz#00bd77e6845fbdb5684c6ab2d8a400a58dcfb07b"
-  integrity sha512-41xatqRwWZuhUMF/aZm2fcUsOFKNcG28xqRSS6ZVr9BVJtGExosLAm5A1OxTjRMagx8nJqva+P5zNIGt8RIgbQ==
+"@typescript-eslint/project-service@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/project-service/-/project-service-8.35.1.tgz#815bb771f2f6c97780e44299434ece3c2e526127"
+  integrity sha512-VYxn/5LOpVxADAuP3NrnxxHYfzVtQzLKeldIhDhzC8UHaiQvYlXvKuVho1qLduFbJjjy5U5bkGwa3rUGUb1Q6Q==
   dependencies:
-    "@typescript-eslint/tsconfig-utils" "^8.35.0"
-    "@typescript-eslint/types" "^8.35.0"
+    "@typescript-eslint/tsconfig-utils" "^8.35.1"
+    "@typescript-eslint/types" "^8.35.1"
     debug "^4.3.4"
 
 "@typescript-eslint/scope-manager@6.18.0":
@@ -3043,28 +3065,38 @@
     "@typescript-eslint/types" "6.18.0"
     "@typescript-eslint/visitor-keys" "6.18.0"
 
-"@typescript-eslint/scope-manager@8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.35.0.tgz#8ccb2ab63383544fab98fc4b542d8d141259ff4f"
-  integrity sha512-+AgL5+mcoLxl1vGjwNfiWq5fLDZM1TmTPYs2UkyHfFhgERxBbqHlNjRzhThJqz+ktBqTChRYY6zwbMwy0591AA==
+"@typescript-eslint/scope-manager@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/scope-manager/-/scope-manager-8.35.1.tgz#b19f9be65c8d1059e88a323a1a6567dbfe0a1a4e"
+  integrity sha512-s/Bpd4i7ht2934nG+UoSPlYXd08KYz3bmjLEb7Ye1UVob0d1ENiT3lY8bsCmik4RqfSbPw9xJJHbugpPpP5JUg==
   dependencies:
-    "@typescript-eslint/types" "8.35.0"
-    "@typescript-eslint/visitor-keys" "8.35.0"
+    "@typescript-eslint/types" "8.35.1"
+    "@typescript-eslint/visitor-keys" "8.35.1"
 
-"@typescript-eslint/tsconfig-utils@8.35.0", "@typescript-eslint/tsconfig-utils@^8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.0.tgz#6e05aeb999999e31d562ceb4fe144f3cbfbd670e"
-  integrity sha512-04k/7247kZzFraweuEirmvUj+W3bJLI9fX6fbo1Qm2YykuBvEhRTPl8tcxlYO8kZZW+HIXfkZNoasVb8EV4jpA==
+"@typescript-eslint/tsconfig-utils@8.35.1", "@typescript-eslint/tsconfig-utils@^8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/tsconfig-utils/-/tsconfig-utils-8.35.1.tgz#c2db8714c181cc0700216c1a2e3cf55719c58006"
+  integrity sha512-K5/U9VmT9dTHoNowWZpz+/TObS3xqC5h0xAIjXPw+MNcKV9qg6eSatEnmeAwkjHijhACH0/N7bkhKvbt1+DXWQ==
+
+"@typescript-eslint/type-utils@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/type-utils/-/type-utils-8.35.1.tgz#4f9a07d6efa0e617a67e1890d28117e68ce154bd"
+  integrity sha512-HOrUBlfVRz5W2LIKpXzZoy6VTZzMu2n8q9C2V/cFngIC5U1nStJgv0tMV4sZPzdf4wQm9/ToWUFPMN9Vq9VJQQ==
+  dependencies:
+    "@typescript-eslint/typescript-estree" "8.35.1"
+    "@typescript-eslint/utils" "8.35.1"
+    debug "^4.3.4"
+    ts-api-utils "^2.1.0"
 
 "@typescript-eslint/types@6.18.0":
   version "6.18.0"
   resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-6.18.0.tgz#ffce610a1540c17cf7d8ecf2bb34b8b0e2e77101"
   integrity sha512-/RFVIccwkwSdW/1zeMx3hADShWbgBxBnV/qSrex6607isYjj05t36P6LyONgqdUrNLl5TYU8NIKdHUYpFvExkA==
 
-"@typescript-eslint/types@8.35.0", "@typescript-eslint/types@^8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.35.0.tgz#e60d062907930e30008d796de5c4170f02618a93"
-  integrity sha512-0mYH3emanku0vHw2aRLNGqe7EXh9WHEhi7kZzscrMDf6IIRUQ5Jk4wp1QrledE/36KtdZrVfKnE32eZCf/vaVQ==
+"@typescript-eslint/types@8.35.1", "@typescript-eslint/types@^8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/types/-/types-8.35.1.tgz#4344dcf934495bbf25a9f83a06dd9fe2acf15780"
+  integrity sha512-q/O04vVnKHfrrhNAscndAn1tuQhIkwqnaW+eu5waD5IPts2eX1dgJxgqcPx5BX109/qAz7IG6VrEPTOYKCNfRQ==
 
 "@typescript-eslint/typescript-estree@6.18.0":
   version "6.18.0"
@@ -3080,21 +3112,31 @@
     semver "^7.5.4"
     ts-api-utils "^1.0.1"
 
-"@typescript-eslint/typescript-estree@8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.0.tgz#86141e6c55b75bc1eaecc0781bd39704de14e52a"
-  integrity sha512-F+BhnaBemgu1Qf8oHrxyw14wq6vbL8xwWKKMwTMwYIRmFFY/1n/9T/jpbobZL8vp7QyEUcC6xGrnAO4ua8Kp7w==
+"@typescript-eslint/typescript-estree@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/typescript-estree/-/typescript-estree-8.35.1.tgz#b80e85fcb6bfbcbacb3224b1367f6ca3f03e6183"
+  integrity sha512-Vvpuvj4tBxIka7cPs6Y1uvM7gJgdF5Uu9F+mBJBPY4MhvjrjWGK4H0lVgLJd/8PWZ23FTqsaJaLEkBCFUk8Y9g==
   dependencies:
-    "@typescript-eslint/project-service" "8.35.0"
-    "@typescript-eslint/tsconfig-utils" "8.35.0"
-    "@typescript-eslint/types" "8.35.0"
-    "@typescript-eslint/visitor-keys" "8.35.0"
+    "@typescript-eslint/project-service" "8.35.1"
+    "@typescript-eslint/tsconfig-utils" "8.35.1"
+    "@typescript-eslint/types" "8.35.1"
+    "@typescript-eslint/visitor-keys" "8.35.1"
     debug "^4.3.4"
     fast-glob "^3.3.2"
     is-glob "^4.0.3"
     minimatch "^9.0.4"
     semver "^7.6.0"
     ts-api-utils "^2.1.0"
+
+"@typescript-eslint/utils@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/utils/-/utils-8.35.1.tgz#a9a0ceeb81c9d132f3f75537ad2ca7f6ca266523"
+  integrity sha512-lhnwatFmOFcazAsUm3ZnZFpXSxiwoa1Lj50HphnDe1Et01NF4+hrdXONSUHIcbVu2eFb1bAf+5yjXkGVkXBKAQ==
+  dependencies:
+    "@eslint-community/eslint-utils" "^4.7.0"
+    "@typescript-eslint/scope-manager" "8.35.1"
+    "@typescript-eslint/types" "8.35.1"
+    "@typescript-eslint/typescript-estree" "8.35.1"
 
 "@typescript-eslint/visitor-keys@6.18.0":
   version "6.18.0"
@@ -3104,12 +3146,12 @@
     "@typescript-eslint/types" "6.18.0"
     eslint-visitor-keys "^3.4.1"
 
-"@typescript-eslint/visitor-keys@8.35.0":
-  version "8.35.0"
-  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.0.tgz#93e905e7f1e94d26a79771d1b1eb0024cb159dbf"
-  integrity sha512-zTh2+1Y8ZpmeQaQVIc/ZZxsx8UzgKJyNg1PTvjzC7WMhPSVS8bfDX34k1SrwOf016qd5RU3az2UxUNue3IfQ5g==
+"@typescript-eslint/visitor-keys@8.35.1":
+  version "8.35.1"
+  resolved "https://registry.yarnpkg.com/@typescript-eslint/visitor-keys/-/visitor-keys-8.35.1.tgz#aac78ab2265dd11927bc6af3f9c5a021bbc1670a"
+  integrity sha512-VRwixir4zBWCSTP/ljEo091lbpypz57PoeAQ9imjG+vbeof9LplljsL1mos4ccG6H9IjfrVGM359RozUnuFhpw==
   dependencies:
-    "@typescript-eslint/types" "8.35.0"
+    "@typescript-eslint/types" "8.35.1"
     eslint-visitor-keys "^4.2.1"
 
 "@ungap/structured-clone@^1.2.0":
@@ -3719,7 +3761,7 @@ babylonjs-editor-tools@latest:
   integrity sha512-+BwvVgR8sYPQNyUO9xNcGEYadbTVSB6QQ0rVmv2X6eW2sJTRxenS89pjQqu9xHvDMht3GBZoFQON+IpNTnjqfg==
 
 "babylonjs-editor-tools@link:tools":
-  version "0.0.11"
+  version "0.0.12"
 
 "babylonjs-editor@link:editor":
   version "5.0.0"
@@ -6247,6 +6289,11 @@ ignore@^5.2.0:
   version "5.3.0"
   resolved "https://registry.yarnpkg.com/ignore/-/ignore-5.3.0.tgz#67418ae40d34d6999c95ff56016759c718c82f78"
   integrity sha512-g7dmpshy+gD7mh88OC9NwSGTKoc3kyLAZQRU1mt53Aw/vnvfXnbC+F/7F7QoYVKbV+KNvJx8wArewKy1vXMtlg==
+
+ignore@^7.0.0:
+  version "7.0.5"
+  resolved "https://registry.yarnpkg.com/ignore/-/ignore-7.0.5.tgz#4cb5f6cd7d4c7ab0365738c7aea888baa6d7efd9"
+  integrity sha512-Hs59xBNfUIunMFgWAbGX5cq6893IbWg4KnrjbYwX3tx0ztorVgTDA6B2sxf8ejHJ4wz8BqGUMYlnzNBer5NvGg==
 
 import-fresh@^3.2.1:
   version "3.3.0"


### PR DESCRIPTION
# Feat: enhance command palette with material support and refactor menu commands

## Problem
Command palette lacked material creation support and menu commands were not unified with the centralized command system.

## Root Cause
- Missing material commands in the command palette infrastructure
- Menu system used hardcoded command arrays instead of centralized functions
- Inconsistent command access across different UI components

## Solution
- Added material command support with unified command structure
- Refactored menu commands to use centralized command functions
- Integrated material commands into inspector and assets browser

## Changes
- **New Material Commands**: Added `material.ts` with PBR, Standard, Node, and Sky material commands
- **Unified Command Keys**: Created `MaterialKey` and `MaterialIPCRendererChannelKey` enums
- **Menu Refactoring**: Updated menu system to use `getMaterialCommands()` instead of hardcoded arrays
- **Enhanced Integration**: Added material commands to inspector and assets browser components

## Benefits
- Consistent command access across all UI components
- Reduced code duplication through centralized command definitions
- Easy extensibility for new material types
- Improved user experience with multiple entry points for material creation