### PR TITLE
Fix getScriptByClassForObject TypeScript typing

### DIFF
--- a/tools/src/loading/script.ts
+++ b/tools/src/loading/script.ts
@@ -119,11 +119,11 @@ export function registerScriptInstance(object: any, scriptInstance: IScript, key
  * 	}
  * }
  */
-export function getAllScriptsByClassForObject<T>(object: any, classType: T) {
+export function getAllScriptsByClassForObject<T extends new (...args: any) => any>(object: any, classType: T) {
 	const data = scriptsDictionary.get(object);
 	const result = data?.filter((s) => s.instance.constructor === classType);
 
-	return result?.map((r) => r.instance) as T[] ?? null;
+	return result?.map((r) => r.instance) as InstanceType<T>[] ?? null;
 }
 
 /**
@@ -146,7 +146,7 @@ export function getAllScriptsByClassForObject<T>(object: any, classType: T) {
  * 	}
  * }
  */
-export function getScriptByClassForObject<T>(object: any, classType: T) {
+export function getScriptByClassForObject<T extends new (...args: any) => any>(object: any, classType: T) {
 	const result = getAllScriptsByClassForObject<T>(object, classType);
-	return result?.[0] as T ?? null;
+	return result?.[0] as InstanceType<T> ?? null;
 }


### PR DESCRIPTION
# Fix getScriptByClassForObject TypeScript typing

## Summary
Fixed the TypeScript typing for `getScriptByClassForObject` function to return the correct instance type instead of the constructor type. This resolves type inference issues where TypeScript was incorrectly inferring the return type as the class constructor rather than an instance of the class.

## Changes Made

### TypeScript Definition Update
- Updated the function signature in `script.d.ts` to use `InstanceType<T>` for the return type
- Added proper generic constraint `T extends new (...args: any[]) => any` to ensure `T` is a class constructor
- This change ensures that when passing a class constructor, the function returns the correct instance type

### Before
```typescript
export declare function getScriptByClassForObject<T>(object: any, classType: T): NonNullable<T> | null;
```

### After
```typescript
export declare function getScriptByClassForObject<T extends new (...args: any[]) => any>(object: any, classType: T): InstanceType<T> | null;
```

## Benefits
- **Improved Developer Experience**: Developers no longer need to manually specify `InstanceType<typeof ClassName>` when using `getScriptByClassForObject`
- **Better Type Safety**: TypeScript now correctly infers instance methods and properties instead of constructor properties
- **Cleaner Code**: Eliminates the need for workarounds like explicit type casting or additional type annotations
- **Consistent API**: The function now behaves as expected - returning an instance when given a class constructor