### PR TITLE
 Add `.webp` Image Support for Assets and Textures

### DIFF
--- a/editor/src/editor/layout/assets-browser.tsx
+++ b/editor/src/editor/layout/assets-browser.tsx
@@ -757,6 +757,7 @@ export class EditorAssetsBrowser extends Component<IEditorAssetsBrowserProps, IE
 			case ".png":
 			case ".jpg":
 			case ".jpeg":
+			case ".webp":
 				return <ImageSelectable {...props} />;
 
 			case ".hdr":
@@ -1085,6 +1086,7 @@ export class EditorAssetsBrowser extends Component<IEditorAssetsBrowserProps, IE
 		switch (extension) {
 			case ".md":
 			case ".png":
+			case ".webp":
 			case ".jpg":
 			case ".bmp":
 			case ".jpeg":

--- a/editor/src/editor/layout/graph/label.tsx
+++ b/editor/src/editor/layout/graph/label.tsx
@@ -209,6 +209,7 @@ export function EditorGraphLabel(props: IEditorGraphLabelProps) {
 				case ".env":
 				case ".jpg":
 				case ".png":
+				case ".webp":
 				case ".bmp":
 				case ".jpeg":
 					applyTextureAssetToObject(props.editor, props.object, absolutePath);

--- a/editor/src/editor/layout/inspector/fields/texture.tsx
+++ b/editor/src/editor/layout/inspector/fields/texture.tsx
@@ -469,6 +469,7 @@ export class EditorInspectorTextureField extends Component<IEditorInspectorTextu
 
 		switch (extension) {
 			case ".png":
+			case ".webp":
 			case ".jpg":
 			case ".jpeg":
 			case ".bmp":

--- a/editor/src/editor/layout/inspector/file.tsx
+++ b/editor/src/editor/layout/inspector/file.tsx
@@ -12,7 +12,7 @@ export class FileInspectorObject {
 	public readonly isFileInspectorObject = true;
 
 	public constructor(
-        public readonly absolutePath: string,
+		public readonly absolutePath: string,
 	) { }
 }
 
@@ -20,10 +20,10 @@ export class EditorFileInspector extends Component<IEditorInspectorImplementatio
 	private _extension: string;
 
 	/**
-     * Returns whether or not the given object is supported by this inspector.
-     * @param object defines the object to check.
-     * @returns true if the object is supported by this inspector.
-     */
+	 * Returns whether or not the given object is supported by this inspector.
+	 * @param object defines the object to check.
+	 * @returns true if the object is supported by this inspector.
+	 */
 	public static IsSupported(object: any): object is FileInspectorObject {
 		return object?.isFileInspectorObject;
 	}
@@ -37,6 +37,7 @@ export class EditorFileInspector extends Component<IEditorInspectorImplementatio
 	public render(): ReactNode {
 		switch (this._extension) {
 			case ".png":
+			case ".webp":
 			case ".jpg":
 			case ".bmp":
 			case ".jpeg":

--- a/editor/src/editor/layout/preview.tsx
+++ b/editor/src/editor/layout/preview.tsx
@@ -1047,6 +1047,7 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 				case ".env":
 				case ".jpg":
 				case ".png":
+				case ".webp":
 				case ".bmp":
 				case ".jpeg":
 					applyTextureAssetToObject(this.props.editor, mesh ?? this.scene, absolutePath);

--- a/editor/src/editor/layout/preview/import/texture.tsx
+++ b/editor/src/editor/layout/preview/import/texture.tsx
@@ -44,6 +44,7 @@ export function applyTextureAssetToObject(editor: Editor, object: any, absoluteP
 
 		case ".jpg":
 		case ".png":
+		case ".webp":
 		case ".bmp":
 		case ".jpeg":
 			const newTexture = configureImportedTexture(new Texture(

--- a/editor/src/project/export/assets.ts
+++ b/editor/src/project/export/assets.ts
@@ -9,7 +9,7 @@ import { compressFileToKtx } from "./ktx";
 import { processExportedTexture } from "./texture";
 
 const supportedImagesExtensions: string[] = [
-	".jpg", ".jpeg",
+	".jpg", ".jpeg", ".webp",
 	".png",
 	".bmp",
 ];


### PR DESCRIPTION
# Add `.webp` Image Support for Assets and Textures

## Summary
This pull request introduces support for the `.webp` image format in all areas where assets and textures are handled. With this change, users can now import, view, and use `.webp` images as assets and textures within the editor, aligning with modern image standards and improving workflow flexibility.

## Changes Made

### Asset and Texture usage
- Added `.webp` to the list of supported image extensions for asset and texture import.
- Updated asset browser and texture picker to recognize and display `.webp` images.
- Ensured `.webp` files are included in file dialogs and drag-and-drop operations for assets and textures.

## Benefits
- Users can now use `.webp` images as assets and textures, enabling better compression and quality.
- Reduces project and asset sizes, improving load times and storage efficiency.
- Enhances compatibility with modern image workflows and user expectations.