### PR TITLE
Feat: Add pan to editor preview

### DIFF
--- a/editor/src/editor/dialogs/edit-preferences/edit-preferences.tsx
+++ b/editor/src/editor/dialogs/edit-preferences/edit-preferences.tsx
@@ -17,6 +17,7 @@ import {
 import { trySetExperimentalFeaturesEnabledInLocalStorage } from "../../../tools/local-storage";
 
 import { EditorInspectorKeyField } from "../../layout/inspector/fields/key";
+import { EditorInspectorNumberField } from "../../layout/inspector/fields/number";
 
 import { Editor } from "../../main";
 
@@ -162,6 +163,18 @@ export class EditorEditPreferencesComponent extends Component<IEditorEditPrefere
 								this._saveCameraControls();
 							}}
 						/>
+
+						<EditorInspectorNumberField
+							object={camera}
+							property="panSensitivityMultiplier"
+							label="Pan Sensitivity"
+							min={0.1}
+							max={50}
+							step={0.5}
+							onChange={() => {
+								this._saveCameraControls();
+							}}
+						/>
 					</div>
 				</div>
 			</div>
@@ -184,6 +197,7 @@ export class EditorEditPreferencesComponent extends Component<IEditorEditPrefere
 					keysRight: camera.keysRight,
 					keysUpward: camera.keysUpward,
 					keysDownward: camera.keysDownward,
+					panSensitivityMultiplier: camera.panSensitivityMultiplier,
 				})
 			);
 		} catch (e) {

--- a/editor/src/editor/layout/inspector/camera/editor.tsx
+++ b/editor/src/editor/layout/inspector/camera/editor.tsx
@@ -37,6 +37,18 @@ export class EditorCameraInspector extends Component<IEditorInspectorImplementat
 					<FocalLengthInspector camera={this.props.object} />
 				</EditorInspectorSectionField>
 
+				<EditorInspectorSectionField title="Controls">
+					<EditorInspectorNumberField
+						object={this.props.object}
+						property="panSensitivityMultiplier"
+						label="Pan Sensitivity"
+						min={0.1}
+						max={50}
+						step={0.5}
+						tooltip="Controls how responsive the camera panning is. Higher values make panning more sensitive."
+					/>
+				</EditorInspectorSectionField>
+
 				<EditorInspectorSectionField title="Keys">
 					<Button variant="secondary" onClick={() => this.props.editor.setState({ editPreferences: true })}>
 						Configure in preferences...

--- a/editor/src/editor/layout/preview.tsx
+++ b/editor/src/editor/layout/preview.tsx
@@ -601,9 +601,9 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 			return;
 		}
 
-       if (event.altKey || event.button === 1) {
-         return;
-       }
+		if (event.altKey || event.button === 1) {
+			return;
+		}
 
 		const distance = Vector2.Distance(this._mouseDownPosition, new Vector2(event.clientX, event.clientY));
 

--- a/editor/src/editor/layout/preview.tsx
+++ b/editor/src/editor/layout/preview.tsx
@@ -601,6 +601,10 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 			return;
 		}
 
+       if (event.altKey || event.button === 1) {
+         return;
+       }
+
 		const distance = Vector2.Distance(this._mouseDownPosition, new Vector2(event.clientX, event.clientY));
 
 		if (distance > 2) {

--- a/editor/src/editor/nodes/camera-pan-input.ts
+++ b/editor/src/editor/nodes/camera-pan-input.ts
@@ -15,11 +15,11 @@ export class EditorFreeCameraPanInput implements ICameraInput<FreeCamera> {
 
 	private _detachedMouseInput: any | null = null;
 
-	private static readonly PAN_SENSITIVITY_MULTIPLIER: number = 10;
-	private static readonly PAN_MIN_DISTANCE: number = 2;
-	private static readonly PAN_MAX_DISTANCE: number = 200;
-	private static readonly PAN_MAX_PIXEL_DELTA: number = 40;
-	private static readonly DEFAULT_FOV: number = Math.PI / 4;
+	public panSensitivityMultiplier: number = 10;
+	private static readonly _panMinDistance: number = 2;
+	private static readonly _panMaxDistance: number = 200;
+	private static readonly _panMaxPixelDelta: number = 40;
+	private static readonly _defaultFov: number = Math.PI / 4;
 
 	private _pointerDownListener: ((ev: PointerEvent) => void) | null = null;
 	private _pointerMoveListener: ((ev: PointerEvent) => void) | null = null;
@@ -163,13 +163,21 @@ export class EditorFreeCameraPanInput implements ICameraInput<FreeCamera> {
 		}
 
 		// Clamp pixel deltas to avoid large single-step jumps on missed frames
-		const maxPix = EditorFreeCameraPanInput.PAN_MAX_PIXEL_DELTA;
-		if (deltaX > maxPix) deltaX = maxPix; else if (deltaX < -maxPix) deltaX = -maxPix;
-		if (deltaY > maxPix) deltaY = maxPix; else if (deltaY < -maxPix) deltaY = -maxPix;
+		const maxPix = EditorFreeCameraPanInput._panMaxPixelDelta;
+		if (deltaX > maxPix) {
+			deltaX = maxPix;
+		} else if (deltaX < -maxPix) {
+			deltaX = -maxPix;
+		}
+		if (deltaY > maxPix) {
+			deltaY = maxPix;
+		} else if (deltaY < -maxPix) {
+			deltaY = -maxPix;
+		}
 
 		const engine = this._scene.getEngine();
 		const renderHeight = engine.getRenderHeight(true);
-		const fov = cam.fov ?? EditorFreeCameraPanInput.DEFAULT_FOV;
+		const fov = cam.fov ?? EditorFreeCameraPanInput._defaultFov;
 
 		// Estimate distance to scene for scaling
 		let distance = 10;
@@ -181,12 +189,9 @@ export class EditorFreeCameraPanInput implements ICameraInput<FreeCamera> {
 			}
 		} catch {}
 
-		const clampedDistance = Math.min(
-			Math.max(distance, EditorFreeCameraPanInput.PAN_MIN_DISTANCE),
-			EditorFreeCameraPanInput.PAN_MAX_DISTANCE
-		);
+		const clampedDistance = Math.min(Math.max(distance, EditorFreeCameraPanInput._panMinDistance), EditorFreeCameraPanInput._panMaxDistance);
 		const worldPerPixelBase = (2 * Math.tan(fov / 2) * Math.max(clampedDistance, 0.0001)) / Math.max(renderHeight, 1);
-		const worldPerPixel = worldPerPixelBase * EditorFreeCameraPanInput.PAN_SENSITIVITY_MULTIPLIER;
+		const worldPerPixel = worldPerPixelBase * this.panSensitivityMultiplier;
 
 		const right = this.camera.getDirection(Vector3.Right());
 		const up = this.camera.getDirection(Vector3.Up());

--- a/editor/src/editor/nodes/camera-pan-input.ts
+++ b/editor/src/editor/nodes/camera-pan-input.ts
@@ -1,0 +1,226 @@
+import { FreeCamera, ICameraInput, Scene, Vector3 } from "babylonjs";
+
+/**
+ * FreeCamera input to pan the camera using Alt + Left Mouse Button.
+ */
+export class EditorFreeCameraPanInput implements ICameraInput<FreeCamera> {
+	public camera: FreeCamera;
+
+	private _scene: Scene;
+	private _canvas: HTMLCanvasElement | null = null;
+
+	private _isPanning: boolean = false;
+	private _lastClientX: number = 0;
+	private _lastClientY: number = 0;
+
+	private _detachedMouseInput: any | null = null;
+
+	private static readonly PAN_SENSITIVITY_MULTIPLIER: number = 10;
+	private static readonly PAN_MIN_DISTANCE: number = 2;
+	private static readonly PAN_MAX_DISTANCE: number = 200;
+	private static readonly PAN_MAX_PIXEL_DELTA: number = 40;
+	private static readonly DEFAULT_FOV: number = Math.PI / 4;
+
+	private _pointerDownListener: ((ev: PointerEvent) => void) | null = null;
+	private _pointerMoveListener: ((ev: PointerEvent) => void) | null = null;
+	private _pointerUpListener: ((ev: PointerEvent) => void) | null = null;
+	private _pointerCancelListener: ((ev: PointerEvent) => void) | null = null;
+
+	public getClassName(): string {
+		return "EditorFreeCameraPanInput";
+	}
+
+	public getSimpleName(): string {
+		return "editorPan";
+	}
+
+	public attachControl(noPreventDefaultOrElement?: any, maybeNoPreventDefault?: boolean): void {
+		let noPreventDefault = false;
+		if (typeof noPreventDefaultOrElement === "boolean") {
+			noPreventDefault = noPreventDefaultOrElement;
+		} else if (typeof maybeNoPreventDefault === "boolean") {
+			noPreventDefault = maybeNoPreventDefault;
+		}
+
+		this._scene = this.camera.getScene();
+		this._canvas = this._scene.getEngine().getRenderingCanvas();
+		if (!this._canvas) {
+			console.warn("EditorFreeCameraPanInput: No canvas found");
+			return;
+		}
+
+		document.addEventListener(
+			"pointerdown",
+			(this._pointerDownListener = (ev: PointerEvent) => {
+				// Only handle events on our canvas
+				if (ev.target !== this._canvas) {
+					return;
+				}
+
+				const isAltLeft = ev.button === 0 && ev.altKey;
+				const isMMB = ev.button === 1; // allow middle mouse to pan as well
+				if (!isAltLeft && !isMMB) {
+					return;
+				}
+
+				this._beginPan(ev);
+				if (!noPreventDefault) {
+					ev.preventDefault();
+					ev.stopPropagation();
+				}
+			}),
+			true
+		);
+
+		document.addEventListener(
+			"pointermove",
+			(this._pointerMoveListener = (ev: PointerEvent) => {
+				if (!this._isPanning) {
+					return;
+				}
+
+				if (!noPreventDefault) {
+					ev.preventDefault();
+					ev.stopPropagation();
+				}
+
+				this._updatePan(ev);
+			}),
+			true
+		);
+
+		const endPan = (ev: PointerEvent) => {
+			if (!this._isPanning) {
+				return;
+			}
+			if (!noPreventDefault) {
+				ev.preventDefault();
+				ev.stopPropagation();
+			}
+			this._endPan(ev);
+		};
+
+		document.addEventListener("pointerup", (this._pointerUpListener = endPan), true);
+		document.addEventListener("pointercancel", (this._pointerCancelListener = endPan), true);
+	}
+
+	public detachControl(): void {
+		if (this._isPanning) {
+			this._endPan();
+		}
+
+		if (this._pointerDownListener) {
+			document.removeEventListener("pointerdown", this._pointerDownListener, true);
+			this._pointerDownListener = null;
+		}
+		if (this._pointerMoveListener) {
+			document.removeEventListener("pointermove", this._pointerMoveListener, true);
+			this._pointerMoveListener = null;
+		}
+		if (this._pointerUpListener) {
+			document.removeEventListener("pointerup", this._pointerUpListener, true);
+			this._pointerUpListener = null;
+		}
+		if (this._pointerCancelListener) {
+			document.removeEventListener("pointercancel", this._pointerCancelListener, true);
+			this._pointerCancelListener = null;
+		}
+
+		this._canvas = null;
+	}
+
+	public checkInputs(): void {
+		// no-op
+	}
+
+	private _beginPan(ev: PointerEvent): void {
+		this._isPanning = true;
+		this._lastClientX = ev.clientX;
+		this._lastClientY = ev.clientY;
+
+		try {
+			(ev.target as any)?.setPointerCapture?.(ev.pointerId);
+		} catch {}
+
+		// Detach default mouse rotation input while panning
+		const attached: any = (this.camera.inputs as any).attached;
+		this._detachedMouseInput = attached?.mouse ?? attached?.pointers ?? null;
+		try {
+			this._detachedMouseInput?.detachControl?.();
+		} catch {}
+
+		try {
+			document.body.style.cursor = "grabbing";
+		} catch {}
+	}
+
+	private _updatePan(ev: PointerEvent): void {
+		const cam = this.camera as any;
+		let deltaX = ev.clientX - this._lastClientX;
+		let deltaY = ev.clientY - this._lastClientY;
+		if (deltaX === 0 && deltaY === 0) {
+			return;
+		}
+
+		// Clamp pixel deltas to avoid large single-step jumps on missed frames
+		const maxPix = EditorFreeCameraPanInput.PAN_MAX_PIXEL_DELTA;
+		if (deltaX > maxPix) deltaX = maxPix; else if (deltaX < -maxPix) deltaX = -maxPix;
+		if (deltaY > maxPix) deltaY = maxPix; else if (deltaY < -maxPix) deltaY = -maxPix;
+
+		const engine = this._scene.getEngine();
+		const renderHeight = engine.getRenderHeight(true);
+		const fov = cam.fov ?? EditorFreeCameraPanInput.DEFAULT_FOV;
+
+		// Estimate distance to scene for scaling
+		let distance = 10;
+		try {
+			const camPos = cam.globalPosition ?? cam.position;
+			const pick = this._scene.pick(this._scene.pointerX, this._scene.pointerY, undefined, false);
+			if (pick?.pickedPoint) {
+				distance = Vector3.Distance(camPos, pick.pickedPoint);
+			}
+		} catch {}
+
+		const clampedDistance = Math.min(
+			Math.max(distance, EditorFreeCameraPanInput.PAN_MIN_DISTANCE),
+			EditorFreeCameraPanInput.PAN_MAX_DISTANCE
+		);
+		const worldPerPixelBase = (2 * Math.tan(fov / 2) * Math.max(clampedDistance, 0.0001)) / Math.max(renderHeight, 1);
+		const worldPerPixel = worldPerPixelBase * EditorFreeCameraPanInput.PAN_SENSITIVITY_MULTIPLIER;
+
+		const right = this.camera.getDirection(Vector3.Right());
+		const up = this.camera.getDirection(Vector3.Up());
+		const offset = right.scale(-deltaX * worldPerPixel).add(up.scale(deltaY * worldPerPixel));
+
+		this.camera.position.addInPlace(offset);
+		if (cam.target && cam.target.addInPlace) {
+			try {
+				cam.target.addInPlace(offset);
+				cam.setTarget?.(cam.target);
+			} catch {}
+		}
+
+		this._lastClientX = ev.clientX;
+		this._lastClientY = ev.clientY;
+	}
+
+	private _endPan(ev?: PointerEvent): void {
+		this._isPanning = false;
+
+		// Re-attach default mouse input if we detached it
+		try {
+			this._detachedMouseInput?.attachControl?.();
+		} catch {}
+		this._detachedMouseInput = null;
+
+		try {
+			if (ev) {
+				(ev.target as any)?.releasePointerCapture?.(ev.pointerId);
+			}
+		} catch {}
+
+		try {
+			document.body.style.cursor = "default";
+		} catch {}
+	}
+}

--- a/editor/src/editor/nodes/camera.ts
+++ b/editor/src/editor/nodes/camera.ts
@@ -5,7 +5,7 @@ import { isDomTextInputFocused } from "../../tools/dom";
 
 export class EditorCamera extends FreeCamera {
 	private _savedSpeed: number | null = null;
-	private _panInput: EditorFreeCameraPanInput | null = null;
+	private _panInput: EditorFreeCameraPanInput;
 
 	private _keyboardUpListener: (ev: KeyboardEvent) => void;
 	private _keyboardDownListener: (ev: KeyboardEvent) => void;
@@ -61,7 +61,6 @@ export class EditorCamera extends FreeCamera {
 		// Add pan input after camera is attached
 		if (this._panInput && !this.inputs.attached.editorPan) {
 			this.inputs.add(this._panInput);
-			console.log("EditorCamera: Added pan input to camera", this._panInput);
 		}
 	}
 

--- a/editor/src/editor/nodes/camera.ts
+++ b/editor/src/editor/nodes/camera.ts
@@ -78,6 +78,11 @@ export class EditorCamera extends FreeCamera {
 			this.keysRight = keys.keysRight;
 			this.keysUpward = keys.keysUpward;
 			this.keysDownward = keys.keysDownward;
+
+			// Load pan sensitivity multiplier if available
+			if (keys.panSensitivityMultiplier !== undefined) {
+				this.panSensitivityMultiplier = keys.panSensitivityMultiplier;
+			}
 		} catch (e) {
 			// Catch silently.
 		}
@@ -99,6 +104,22 @@ export class EditorCamera extends FreeCamera {
 	 */
 	public getClassName(): string {
 		return "EditorCamera";
+	}
+
+	/**
+	 * Gets the pan sensitivity multiplier for the camera pan input.
+	 * @returns the current pan sensitivity multiplier value.
+	 */
+	public get panSensitivityMultiplier(): number {
+		return this._panInput.panSensitivityMultiplier;
+	}
+
+	/**
+	 * Sets the pan sensitivity multiplier for the camera pan input.
+	 * @param value defines the new pan sensitivity multiplier value.
+	 */
+	public set panSensitivityMultiplier(value: number) {
+		this._panInput.panSensitivityMultiplier = value;
 	}
 }
 

--- a/editor/src/editor/nodes/camera.ts
+++ b/editor/src/editor/nodes/camera.ts
@@ -1,9 +1,11 @@
 import { Node, FreeCamera, Scene, Vector3 } from "babylonjs";
+import { EditorFreeCameraPanInput } from "./camera-pan-input";
 
 import { isDomTextInputFocused } from "../../tools/dom";
 
 export class EditorCamera extends FreeCamera {
 	private _savedSpeed: number | null = null;
+	private _panInput: EditorFreeCameraPanInput | null = null;
 
 	private _keyboardUpListener: (ev: KeyboardEvent) => void;
 	private _keyboardDownListener: (ev: KeyboardEvent) => void;
@@ -19,6 +21,7 @@ export class EditorCamera extends FreeCamera {
 		super(name, position, scene, setActiveOnSceneIfNoneActive);
 
 		this.inputs.addMouseWheel();
+		this._panInput = new EditorFreeCameraPanInput();
 
 		window.addEventListener(
 			"keydown",
@@ -47,6 +50,19 @@ export class EditorCamera extends FreeCamera {
 				}
 			})
 		);
+	}
+
+	/**
+	 * Override attachControl to ensure pan input is attached
+	 */
+	public attachControl(noPreventDefault?: boolean): void {
+		super.attachControl(noPreventDefault);
+
+		// Add pan input after camera is attached
+		if (this._panInput && !this.inputs.attached.editorPan) {
+			this.inputs.add(this._panInput);
+			console.log("EditorCamera: Added pan input to camera", this._panInput);
+		}
 	}
 
 	/**

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -2,8 +2,8 @@ import { platform } from "os";
 import { ipcMain, shell } from "electron";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
-    const isWindows = platform() === "win32";
-    items = items.map((item) => (isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/")));
+	const isWindows = platform() === "win32";
+	items = items.map((item) => (isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/")));
 
 	try {
 		await Promise.all(items.map((item) => shell.trashItem(item)));
@@ -15,8 +15,8 @@ ipcMain.on("editor:trash-items", async (ev, items) => {
 });
 
 ipcMain.on("editor:show-item", (_, item) => {
-    const isWindows = platform() === "win32";
-    item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
+	const isWindows = platform() === "win32";
+	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
 
 	shell.showItemInFolder(item);
 });


### PR DESCRIPTION
# Title

## Summary
Add pan to the Editor preview.

If the user presses ~shift~ alt and clicks with the left mouse button, instead of rotating, the camera will move.

## Changes Made
In the preview component `src/editor/layout/preview.tsx` methods to handle the mouse events were added. The original behavior was preserved.

Some constants were added to make the movement more smooth and natural. 

## Benefits
With this change, the experience is more natural and it's easier to navigate the scene than using tilt and zoom.