### PR TITLE
Feat: Load 3d mesh model

### DIFF
--- a/editor/src/editor/dialogs/command-palette/mesh.ts
+++ b/editor/src/editor/dialogs/command-palette/mesh.ts
@@ -2,7 +2,7 @@ import { Node } from "babylonjs";
 
 import { Editor } from "../../main";
 
-import { addTransformNode, addBoxMesh, addGroundMesh, addSphereMesh, addPlaneMesh, addSkyboxMesh, addEmptyMesh } from "../../../project/add/mesh";
+import { addTransformNode, addBoxMesh, addGroundMesh, addSphereMesh, addPlaneMesh, addSkyboxMesh, addEmptyMesh, addModelMesh } from "../../../project/add/mesh";
 
 import { meshCommandItems } from "./shared-commands";
 import { ICommandPaletteType } from "./command-palette";
@@ -36,6 +36,10 @@ export function getMeshCommands(editor?: Editor, parent?: Node): ICommandPalette
 		{
 			...meshCommandItems.emptyMesh,
 			action: () => editor && addEmptyMesh(editor, parent),
+		},
+		{
+			...meshCommandItems.modelMesh,
+			action: () => editor && addModelMesh(editor, parent),
 		},
 	];
 }

--- a/editor/src/editor/dialogs/command-palette/shared-commands.ts
+++ b/editor/src/editor/dialogs/command-palette/shared-commands.ts
@@ -87,4 +87,10 @@ export const meshCommandItems = {
 		key: "add-empty-mesh",
 		ipcRendererChannelKey: "empty-mesh",
 	} as CommandItem,
+	modelMesh: {
+		text: "Model Mesh",
+		label: "Import a 3D model",
+		key: "add-model-mesh",
+		ipcRendererChannelKey: "model-mesh",
+	} as CommandItem,
 };

--- a/editor/src/editor/layout/preview/import/import.ts
+++ b/editor/src/editor/layout/preview/import/import.ts
@@ -65,6 +65,28 @@ export async function loadImportedSceneFile(scene: Scene, absolutePath: string, 
 		root?.scaling.scaleInPlace(100);
 	}
 
+	// Rename imported roots named "__root__" to a friendly name derived from the filename
+	const baseFileName = basename(absolutePath).replace(/\.[^/.]+$/, "");
+	const getUniqueName = (proposed: string): string => {
+		let uniqueName = proposed;
+		let suffix = 1;
+		while (scene.getNodeByName(uniqueName)) {
+			uniqueName = `${proposed}_${suffix++}`;
+		}
+		return uniqueName;
+	};
+
+	result.meshes.forEach((mesh) => {
+		if (mesh.name === "__root__") {
+			mesh.name = getUniqueName(baseFileName);
+		}
+	});
+	result.transformNodes.forEach((tn) => {
+		if (tn.name === "__root__") {
+			tn.name = getUniqueName(baseFileName);
+		}
+	});
+
 	result.meshes.forEach((mesh) => {
 		configureImportedNodeIds(mesh);
 


### PR DESCRIPTION
# Title
Add ability to add 3d Models (as Mesh)

## Summary
In the "Add" (menu option) add a new item which is Model Mesh, when clicked, this option opens a file dialog that accepts the 3d formats supported by babylon.js

## Changes Made

### New getMeshCommands added
Added a new mesh command to include the mesh

### In the mesh.ts a new method was added
addModelMesh method was added to handle the model case

### Added new item to the meshCommands in the shared-commands
modelMesh was added to the meshCommands constants 

### In the editor/src/editor/layout/preview/import/import.ts
I added a logic to change the name of the model in the layer from `__root__` to the actual filename without the extension (similar to what Unity does).

## Benefits
With this change, users can load their 3d models instead of only primitives.
