### PR TITLE
[Linux] Fix show in explorer

### DIFF
--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -2,7 +2,8 @@ import { platform } from "os";
 import { ipcMain, shell } from "electron";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
-	items = platform() === "darwin" ? items.map((item) => item.replace(/\\/g, "/")) : items.map((item) => item.replace(/\//g, "\\"));
+    const isWindows = platform() === "win32";
+    items = items.map((item) => (isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/")));
 
 	try {
 		await Promise.all(items.map((item) => shell.trashItem(item)));
@@ -14,7 +15,8 @@ ipcMain.on("editor:trash-items", async (ev, items) => {
 });
 
 ipcMain.on("editor:show-item", (_, item) => {
-	item = platform() === "darwin" ? item.replace(/\\/g, "/") : item.replace(/\//g, "\\");
+    const isWindows = platform() === "win32";
+    item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
 
 	shell.showItemInFolder(item);
 });


### PR DESCRIPTION
# Title
[Linux] Fix show in explorer

## Summary
Fix "Show in Explorer" on Linux

## Changes Made

### Modified shell command
Currently, the shell command handles the case when the OS is darwin but is doesn't handle the case when it uses other unix systems. For this reason the option to Show in Explorer always opens an error dialog:

<img width="327" height="157" alt="Screenshot From 2025-08-08 00-42-22" src="https://github.com/user-attachments/assets/ce837b49-eace-449b-a832-d125372331c6" />

## Benefits
- With this fix, is possible to use the Show in Explorer feature on Linux.
