### PR TITLE
Add more properties to pbr materials

### DIFF
--- a/editor/src/editor/layout/inspector/material/pbr.tsx
+++ b/editor/src/editor/layout/inspector/material/pbr.tsx
@@ -55,6 +55,7 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 							<>
 								<EditorInspectorSwitchField label="Inverse X" object={this.props.material} property="invertNormalMapX" />
 								<EditorInspectorSwitchField label="Inverse Y" object={this.props.material} property="invertNormalMapY" />
+								<EditorInspectorSwitchField label="Use Object Space Normal Map" object={this.props.material} property="useObjectSpaceNormalMap" />
 								<EditorInspectorSwitchField label="Use Parallax" object={this.props.material} property="useParallax" onChange={() => this.forceUpdate()} />
 
 								{this.props.material.useParallax && (
@@ -63,6 +64,7 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 										<EditorInspectorNumberField label="Parallax Scale Bias" object={this.props.material} property="parallaxScaleBias" />
 									</>
 								)}
+								<EditorInspectorSwitchField label="Disable Bump Map" object={this.props.material} property="disableBumpMap" onChange={() => this.forceUpdate()} />
 							</>
 						)}
 					</EditorInspectorTextureField>
@@ -89,7 +91,13 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 							<>
 								<EditorInspectorSwitchField label="Use Gray Scale" object={this.props.material} property="useAmbientInGrayScale" />
 								<EditorInspectorNumberField label="Strength" object={this.props.material} property="ambientTextureStrength" min={0} />
-								<EditorInspectorNumberField label="Impact On Analytical Lights" object={this.props.material} property="ambientTextureImpactOnAnalyticalLights" min={0} max={1} />
+								<EditorInspectorNumberField
+									label="Impact On Analytical Lights"
+									object={this.props.material}
+									property="ambientTextureImpactOnAnalyticalLights"
+									min={0}
+									max={1}
+								/>
 							</>
 						)}
 					</EditorInspectorTextureField>
@@ -124,6 +132,13 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					</EditorInspectorTextureField>
 
 					<EditorInspectorTextureField object={this.props.material} title="Emissive Texture" property="emissiveTexture" />
+					<EditorInspectorTextureField object={this.props.material} title="Lightmap Texture" property="lightmapTexture">
+						{this.props.material.lightmapTexture && (
+							<>
+								<EditorInspectorSwitchField label="Use Lightmap As Shadowmap" object={this.props.material} property="useLightmapAsShadowmap" />
+							</>
+						)}
+					</EditorInspectorTextureField>
 				</EditorInspectorSectionField>
 
 				<EditorInspectorSectionField title="Material Colors">
@@ -132,7 +147,9 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					<EditorInspectorColorField label={<div className="w-14">Reflection</div>} object={this.props.material} property="reflectionColor" />
 					<EditorInspectorColorField label={<div className="w-14">Ambient</div>} object={this.props.material} property="ambientColor" />
 					<EditorInspectorColorField label={<div className="w-14">Emissive</div>} object={this.props.material} property="emissiveColor" />
-					<EditorInspectorColorField label={<div className="w-14">Metallic Reflectance</div>} object={this.props.material} property="metallicReflectanceColor" />
+					{this.props.material.metallic !== null && (
+						<EditorInspectorColorField label={<div className="w-14">Metallic Reflectance</div>} object={this.props.material} property="metallicReflectanceColor" />
+					)}
 				</EditorInspectorSectionField>
 
 				<EditorInspectorSectionField title="Metallic / Roughness">
@@ -178,6 +195,11 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					/>
 
 					{this.props.material.roughness !== null && <EditorInspectorNumberField label=" " object={this.props.material} property="roughness" min={0} max={1} />}
+					<EditorInspectorSwitchField
+						label="Use Only Metallic From Metallic Reflectance Texture"
+						object={this.props.material}
+						property="useOnlyMetallicFromMetallicReflectanceTexture"
+					/>
 				</EditorInspectorSectionField>
 
 				{this.props.material.metallic === null && this.props.material.roughness === null && (
@@ -210,27 +232,18 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 				<EditorInspectorSectionField title="Misc">
 					<EditorInspectorSwitchField label="Unlit" object={this.props.material} property="unlit" />
 					<EditorInspectorSwitchField label="Disable Lighting" object={this.props.material} property="disableLighting" />
-					<EditorInspectorSwitchField label="Use Specular Over Alpha" object={this.props.material} property="useSpecularOverAlpha" />
 					<EditorInspectorSwitchField label="Enable Specular Anti Aliasing" object={this.props.material} property="enableSpecularAntiAliasing" />
 					<EditorInspectorSwitchField label="Force Irradiance In Fragment" object={this.props.material} property="forceIrradianceInFragment" />
 					<EditorInspectorSwitchField label="Use Radiance Occlusion" object={this.props.material} property="useRadianceOcclusion" />
-					<EditorInspectorSwitchField label="Use Physical Light Falloff" object={this.props.material} property="usePhysicalLightFalloff" />
-					<EditorInspectorSwitchField label="Use GLTF Light Falloff" object={this.props.material} property="useGLTFLightFalloff" />
-					<EditorInspectorSwitchField label="Use Radiance Over Alpha" object={this.props.material} property="useRadianceOverAlpha" />
-					<EditorInspectorSwitchField label="Use Object Space Normal Map" object={this.props.material} property="useObjectSpaceNormalMap" />
 					<EditorInspectorSwitchField label="Use Horizon Occlusion" object={this.props.material} property="useHorizonOcclusion" />
+					<EditorInspectorSwitchField label="Use Physical Light Falloff" object={this.props.material} property="usePhysicalLightFalloff" />
+					<EditorInspectorSwitchField label="Use Radiance Over Alpha" object={this.props.material} property="useRadianceOverAlpha" />
+					<EditorInspectorSwitchField label="Use Specular Over Alpha" object={this.props.material} property="useSpecularOverAlpha" />
 					<EditorInspectorSwitchField label="Separate Culling Pass" object={this.props.material} property="separateCullingPass" />
-					<EditorInspectorSwitchField label="Use Lightmap As Shadowmap" object={this.props.material} property="useLightmapAsShadowmap" />
-					<EditorInspectorSwitchField label="Disable Bump Map" object={this.props.material} property="disableBumpMap" />
-					<EditorInspectorSwitchField label="Use Alpha From Albedo Texture" object={this.props.material} property="useAlphaFromAlbedoTexture" />
 					<EditorInspectorSwitchField label="Force Alpha Test" object={this.props.material} property="forceAlphaTest" />
-					<EditorInspectorSwitchField label="Use Only Metallic From Metallic Reflectance Texture" object={this.props.material} property="useOnlyMetallicFromMetallicReflectanceTexture" />
 					<EditorInspectorNumberField label="Z Offset" object={this.props.material} property="zOffset" />
 					<EditorInspectorNumberField label="Z Offset Units" object={this.props.material} property="zOffsetUnits" />
-					<EditorInspectorNumberField label="Point Size" object={this.props.material} property="pointSize" min={0} />
-					<EditorInspectorSwitchField label="Points Cloud" object={this.props.material} property="pointsCloud" />
 					<EditorInspectorSwitchField label="Fog Enabled" object={this.props.material} property="fogEnabled" />
-					<EditorInspectorNumberField label="Max Simultaneous Lights" object={this.props.material} property="maxSimultaneousLights" min={0} />
 				</EditorInspectorSectionField>
 			</>
 		);

--- a/editor/src/editor/layout/inspector/material/pbr.tsx
+++ b/editor/src/editor/layout/inspector/material/pbr.tsx
@@ -89,6 +89,7 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 							<>
 								<EditorInspectorSwitchField label="Use Gray Scale" object={this.props.material} property="useAmbientInGrayScale" />
 								<EditorInspectorNumberField label="Strength" object={this.props.material} property="ambientTextureStrength" min={0} />
+								<EditorInspectorNumberField label="Impact On Analytical Lights" object={this.props.material} property="ambientTextureImpactOnAnalyticalLights" min={0} max={1} />
 							</>
 						)}
 					</EditorInspectorTextureField>
@@ -131,10 +132,12 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					<EditorInspectorColorField label={<div className="w-14">Reflection</div>} object={this.props.material} property="reflectionColor" />
 					<EditorInspectorColorField label={<div className="w-14">Ambient</div>} object={this.props.material} property="ambientColor" />
 					<EditorInspectorColorField label={<div className="w-14">Emissive</div>} object={this.props.material} property="emissiveColor" />
+					<EditorInspectorColorField label={<div className="w-14">Metallic Reflectance</div>} object={this.props.material} property="metallicReflectanceColor" />
 				</EditorInspectorSectionField>
 
 				<EditorInspectorSectionField title="Metallic / Roughness">
 					<EditorInspectorNumberField label="Metallic F0 Factor" object={this.props.material} property="metallicF0Factor" />
+					<EditorInspectorNumberField label="Base Weight" object={this.props.material} property="baseWeight" min={0} max={1} />
 
 					<EditorInspectorSwitchField
 						label="Metallic"
@@ -197,9 +200,14 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					</EditorInspectorSectionField>
 				)}
 
-				<EditorInspectorSectionField title="Misc">
+				<EditorInspectorSectionField title="Intensity Properties">
 					<EditorInspectorNumberField label="Direct Intensity" object={this.props.material} property="directIntensity" min={0} />
 					<EditorInspectorNumberField label="Environment Intensity" object={this.props.material} property="environmentIntensity" min={0} />
+					<EditorInspectorNumberField label="Emissive Intensity" object={this.props.material} property="emissiveIntensity" min={0} />
+					<EditorInspectorNumberField label="Specular Intensity" object={this.props.material} property="specularIntensity" min={0} />
+				</EditorInspectorSectionField>
+
+				<EditorInspectorSectionField title="Misc">
 					<EditorInspectorSwitchField label="Unlit" object={this.props.material} property="unlit" />
 					<EditorInspectorSwitchField label="Disable Lighting" object={this.props.material} property="disableLighting" />
 					<EditorInspectorSwitchField label="Use Specular Over Alpha" object={this.props.material} property="useSpecularOverAlpha" />
@@ -207,8 +215,22 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					<EditorInspectorSwitchField label="Force Irradiance In Fragment" object={this.props.material} property="forceIrradianceInFragment" />
 					<EditorInspectorSwitchField label="Use Radiance Occlusion" object={this.props.material} property="useRadianceOcclusion" />
 					<EditorInspectorSwitchField label="Use Physical Light Falloff" object={this.props.material} property="usePhysicalLightFalloff" />
+					<EditorInspectorSwitchField label="Use GLTF Light Falloff" object={this.props.material} property="useGLTFLightFalloff" />
+					<EditorInspectorSwitchField label="Use Radiance Over Alpha" object={this.props.material} property="useRadianceOverAlpha" />
+					<EditorInspectorSwitchField label="Use Object Space Normal Map" object={this.props.material} property="useObjectSpaceNormalMap" />
+					<EditorInspectorSwitchField label="Use Horizon Occlusion" object={this.props.material} property="useHorizonOcclusion" />
 					<EditorInspectorSwitchField label="Separate Culling Pass" object={this.props.material} property="separateCullingPass" />
+					<EditorInspectorSwitchField label="Use Lightmap As Shadowmap" object={this.props.material} property="useLightmapAsShadowmap" />
+					<EditorInspectorSwitchField label="Disable Bump Map" object={this.props.material} property="disableBumpMap" />
+					<EditorInspectorSwitchField label="Use Alpha From Albedo Texture" object={this.props.material} property="useAlphaFromAlbedoTexture" />
+					<EditorInspectorSwitchField label="Force Alpha Test" object={this.props.material} property="forceAlphaTest" />
+					<EditorInspectorSwitchField label="Use Only Metallic From Metallic Reflectance Texture" object={this.props.material} property="useOnlyMetallicFromMetallicReflectanceTexture" />
 					<EditorInspectorNumberField label="Z Offset" object={this.props.material} property="zOffset" />
+					<EditorInspectorNumberField label="Z Offset Units" object={this.props.material} property="zOffsetUnits" />
+					<EditorInspectorNumberField label="Point Size" object={this.props.material} property="pointSize" min={0} />
+					<EditorInspectorSwitchField label="Points Cloud" object={this.props.material} property="pointsCloud" />
+					<EditorInspectorSwitchField label="Fog Enabled" object={this.props.material} property="fogEnabled" />
+					<EditorInspectorNumberField label="Max Simultaneous Lights" object={this.props.material} property="maxSimultaneousLights" min={0} />
 				</EditorInspectorSectionField>
 			</>
 		);

--- a/editor/src/editor/layout/inspector/material/pbr.tsx
+++ b/editor/src/editor/layout/inspector/material/pbr.tsx
@@ -131,6 +131,19 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 						)}
 					</EditorInspectorTextureField>
 
+					<EditorInspectorTextureField object={this.props.material} title="Metallic Reflectance Texture" property="metallicReflectanceTexture" onChange={() => this.forceUpdate()}>
+						{this.props.material.metallicReflectanceTexture && (
+							<>
+								<EditorInspectorSwitchField
+									label="Use Only Metallic From Metallic Reflectance Texture"
+									object={this.props.material}
+									property="useOnlyMetallicFromMetallicReflectanceTexture"
+									onChange={() => this.forceUpdate()}
+								/>
+							</>
+						)}
+					</EditorInspectorTextureField>
+
 					<EditorInspectorTextureField object={this.props.material} title="Emissive Texture" property="emissiveTexture" />
 					<EditorInspectorTextureField object={this.props.material} title="Lightmap Texture" property="lightmapTexture">
 						{this.props.material.lightmapTexture && (
@@ -195,11 +208,6 @@ export class EditorPBRMaterialInspector extends Component<IEditorPBRMaterialInsp
 					/>
 
 					{this.props.material.roughness !== null && <EditorInspectorNumberField label=" " object={this.props.material} property="roughness" min={0} max={1} />}
-					<EditorInspectorSwitchField
-						label="Use Only Metallic From Metallic Reflectance Texture"
-						object={this.props.material}
-						property="useOnlyMetallicFromMetallicReflectanceTexture"
-					/>
 				</EditorInspectorSectionField>
 
 				{this.props.material.metallic === null && this.props.material.roughness === null && (


### PR DESCRIPTION
#Title
## Summary

Add more properties to Standard Materials
## Changes Made

Modified the inspector/material/standard.tsx file to include new properties

### Properties Added:

- Impact On Analytical Lights
- Metallic Reflectance
-Base Weight
- Emissive Intensity
- Specular Intensity
- Use GLTF Light Falloff
- Use Radiance Over Alpha
- Use Object Space Normal Map
- Use Horizon Occlusion
- Use Lightmap As Shadowmap
- Disable Bump Map
- Use Alpha From Albedo Texture
- Force Alpha Test
- Use Only Metallic From Metallic Reflectance Texture
- Z Offset Units
- Fog Enabled

## Benefits

Helps with https://github.com/BabylonJS/Editor/issues/523