### PR TITLE
Fix loading bones

### DIFF
--- a/editor/src/electron/assimp/assimpjs-worker.ts
+++ b/editor/src/electron/assimp/assimpjs-worker.ts
@@ -3,11 +3,18 @@ import { workerData, parentPort } from "worker_threads";
 
 const assimpjs = require("assimpjs")();
 
+const AssimpPostProcessFlags = {
+	aiProcess_LimitBoneWeights: 0x200000,
+} as const;
+
 assimpjs.then((ajs) => {
 	const fileList = new ajs.FileList();
 	fileList.AddFile(basename(workerData.absolutePath), new Uint8Array(workerData.content));
 
-	const result = ajs.ConvertFileList(fileList, "assjson");
+	const postProcessFlags =
+		AssimpPostProcessFlags.aiProcess_LimitBoneWeights;
+	const result = ajs.ConvertFileList(fileList, "assjson", postProcessFlags);
+
 	if (!result.IsSuccess() || result.FileCount() === 0) {
 		console.log(result.GetErrorCode());
 		return parentPort?.postMessage(null);

--- a/editor/src/loader/animation.ts
+++ b/editor/src/loader/animation.ts
@@ -95,5 +95,12 @@ function getNodeFromContainerByName(container: AssetContainer, name: string): Tr
 		return mesh;
 	}
 
+	for (const skeleton of container.skeletons) {
+		const bone = skeleton.bones.find((b) => b.name === name);
+		if (bone) {
+			return bone;
+		}
+	}
+
 	return null;
 }

--- a/editor/src/loader/mesh.ts
+++ b/editor/src/loader/mesh.ts
@@ -61,7 +61,7 @@ export function parseMesh(runtime: AssimpJSRuntime, data: IAssimpJSNodeData): Me
 	}
 
 	// Bones
-	const hasBones = !meshes.find((m) => !m.bones);
+	const hasBones = meshes.some((m) => m.bones && m.bones.length > 0);
 
 	if (hasBones) {
 		const skeleton = new Skeleton(data.name, Tools.RandomId(), runtime.scene);


### PR DESCRIPTION
# Title
Fix loading bones from assimp. I couldn't test it yet, but shouldn't be a bad idea to merge it. I will probably test it tomorrow.

## Summary
Fix 3 places in the code to make sure bones are loading and handled properly

## Changes Made

### Modify logic to determine if meshes have bones
- Instead of checking if all the meshes have bones, we check if _any_ mesh has bones

### Add a way to retrieve a bone from a container by name
- Updates the `getNodeFromContainerByName` method to allow retrieving a bone by name

### Update the assimp worker to limit bone weights
- Change the call to load a model using assimp to pass the flags to limit bone weights

## Benefits
Closes #506
