### PR TITLE
[UX] Toggle switch on click

### DIFF
--- a/editor/src/editor/layout/inspector/fields/switch.tsx
+++ b/editor/src/editor/layout/inspector/fields/switch.tsx
@@ -16,7 +16,9 @@ export function EditorInspectorSwitchField(props: IEditorInspectorSwitchFieldPro
 
 	return (
 		<div
-			onClick={() => {
+			onClick={(ev) => {
+				ev.stopPropagation();
+
 				setValue(!value);
 				setInspectorEffectivePropertyValue(props.object, props.property, !value);
 				props.onChange?.(!value);
@@ -36,7 +38,7 @@ export function EditorInspectorSwitchField(props: IEditorInspectorSwitchFieldPro
 			<div className="w-full text-ellipsis overflow-hidden whitespace-nowrap">{props.label}</div>
 
 			<div className="flex justify-end w-14 py-2">
-				<Switch checked={value} onChange={() => {}} onClick={(ev) => ev.stopPropagation()} />
+				<Switch checked={value} onChange={() => {}} />
 			</div>
 		</div>
 	);


### PR DESCRIPTION
# Title

## Summary
When user clicks on the switch (UI component) the value of the switch changes

## Changes Made

### Moved stop propagation
Instead of keeping the stop propagation at the switch component, I moved it to the label so the label manages it.

## Benefits
- Is less confusing since users can now toggle the switch clicking on the switch instead of only the label 
