### PR TITLE
[UX] Delete objects when pressing delete

### DIFF
--- a/editor/src/editor/main.tsx
+++ b/editor/src/editor/main.tsx
@@ -37,6 +37,7 @@ import { removeNodes } from "./layout/graph/remove";
 
 import "./nodes/camera";
 import "./nodes/scene-link";
+import { isDomTextInputFocused } from "../tools/dom";
 
 export function createEditor(): void {
 	const theme = localStorage.getItem("editor-theme") ?? "dark";
@@ -161,9 +162,11 @@ export class Editor extends Component<IEditorProps, IEditorState> {
 							preventDefault: true,
 							label: "Delete Selected Objects",
 							onKeyDown: () => {
-								const selectedNodes = this.layout.graph.getSelectedNodes();
-								if (selectedNodes.length > 0) {
-									removeNodes(this);
+								if (!isDomTextInputFocused()) {
+									const selectedNodes = this.layout.graph.getSelectedNodes();
+									if (selectedNodes.length > 0) {
+										removeNodes(this);
+									}
 								}
 							},
 						},

--- a/editor/src/editor/main.tsx
+++ b/editor/src/editor/main.tsx
@@ -33,6 +33,7 @@ import { EditorEditPreferencesComponent } from "./dialogs/edit-preferences/edit-
 import { Toaster } from "../ui/shadcn/ui/sonner";
 
 import { EditorLayout } from "./layout";
+import { removeNodes } from "./layout/graph/remove";
 
 import "./nodes/camera";
 import "./nodes/scene-link";
@@ -153,6 +154,18 @@ export class Editor extends Component<IEditorProps, IEditorState> {
 							preventDefault: true,
 							label: "Show Command Palette",
 							onKeyDown: () => this.commandPalette.setOpen(true),
+						},
+						{
+							global: true,
+							combo: "delete",
+							preventDefault: true,
+							label: "Delete Selected Objects",
+							onKeyDown: () => {
+								const selectedNodes = this.layout.graph.getSelectedNodes();
+								if (selectedNodes.length > 0) {
+									removeNodes(this);
+								}
+							},
 						},
 					]}
 				>


### PR DESCRIPTION
# Title

## Summary
Delete objects when pressing delete

## Changes Made

### Modified main.ts
Added a global hotkey (delete) to remove a node from the scene

## Benefits
- User can delete objects pressing the delete key instead of using mouse 