### PR TITLE
[UX] Alternative render options button

### DIFF
--- a/editor/src/editor/layout/preview.tsx
+++ b/editor/src/editor/layout/preview.tsx
@@ -7,9 +7,9 @@ import { Component, MouseEvent, ReactNode } from "react";
 import { Grid } from "react-loader-spinner";
 
 import { FaCheck } from "react-icons/fa6";
-import { IoIosOptions, IoIosStats } from "react-icons/io";
+import { GiArrowCursor, GiTeapot, GiWireframeGlobe } from "react-icons/gi";
+import { IoIosStats } from "react-icons/io";
 import { LuMove3D, LuRotate3D, LuScale3D } from "react-icons/lu";
-import { GiArrowCursor, GiWireframeGlobe } from "react-icons/gi";
 
 import {
 	AbstractEngine,
@@ -846,7 +846,7 @@ export class EditorPreview extends Component<IEditorPreviewProps, IEditorPreview
 					<DropdownMenu>
 						<DropdownMenuTrigger asChild>
 							<Button variant="ghost" className="px-1 py-1 w-9 h-9">
-								<IoIosOptions className="w-6 h-6" strokeWidth={1} />
+								<GiTeapot className="w-6 h-6" strokeWidth={1} />
 							</Button>
 						</DropdownMenuTrigger>
 						<DropdownMenuContent onClick={() => this.forceUpdate()}>


### PR DESCRIPTION
# Title
Replace render options button to teapot icon

## Summary
When I see the options icon is not clear to me that those are render options. I believe teapot became a symbol of render. If I am not mistaken, V-Ray had the render button as a teapot. 

## Changes Made

### Replace the IoioOptions icon with Teapot icon
| Old | New |
|-------|--------|
|<img width="46" height="43" alt="Screenshot From 2025-08-22 00-00-29" src="https://github.com/user-attachments/assets/35827750-677e-4a13-835f-aafd00a8975f" />|<img width="46" height="43" alt="Screenshot From 2025-08-22 00-01-05" src="https://github.com/user-attachments/assets/810c50c4-28fc-4d0b-821a-3a31defb397c" />|

## Benefits
- More intuitive icon for "Render Options"

PS: I know this is very subjective so feel free to close this PR.
