### PR TITLE
[UX] Add model preview

### DIFF
--- a/editor/src/editor/layout/assets-browser/items/mesh-item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/mesh-item.tsx
@@ -3,20 +3,29 @@ import { writeJSON } from "fs-extra";
 import { ReactNode } from "react";
 
 import { SiConvertio } from "react-icons/si";
-import { BiSolidCube } from "react-icons/bi";
 
 import { Scene, SceneSerializer } from "babylonjs";
+
+import { ModelThumbnailRenderer } from "../renderers/model-thumbnail";
 
 import { SpinnerUIComponent } from "../../../../ui/spinner";
 import { ContextMenuItem } from "../../../../ui/shadcn/ui/context-menu";
 
 import { loadImportedSceneFile } from "../../preview/import/import";
+import { openModelViewer } from "../viewers/model-viewer";
 
 import { AssetsBrowserItem } from "./item";
 
 const convertingFiles: string[] = [];
 
 export class AssetBrowserMeshItem extends AssetsBrowserItem {
+	/**
+	 * @override
+	 */
+	protected async onDoubleClick(): Promise<void> {
+		openModelViewer(this.props.editor, this.props.absolutePath);
+	}
+
 	/**
 	 * @override
 	 */
@@ -39,7 +48,11 @@ export class AssetBrowserMeshItem extends AssetsBrowserItem {
 			return <SpinnerUIComponent width="64px" />;
 		}
 
-		return <BiSolidCube size="64px" />;
+		return (
+			<div className="w-full h-full pointer-events-none">
+				<ModelThumbnailRenderer absolutePath={this.props.absolutePath} />
+			</div>
+		);
 	}
 
 	private async _handleConvertSceneFileToBabylon(): Promise<void> {

--- a/editor/src/editor/layout/assets-browser/renderers/model-thumbnail.tsx
+++ b/editor/src/editor/layout/assets-browser/renderers/model-thumbnail.tsx
@@ -1,0 +1,112 @@
+import { useEffect, useRef, useState } from "react";
+import { Engine, Scene, Vector3, DirectionalLight, HemisphericLight, ArcRotateCamera, CubeTexture, Color3, SceneLoader } from "babylonjs";
+import { basename, dirname, join } from "path/posix";
+
+import { BiSolidCube } from "react-icons/bi";
+
+import { projectConfiguration } from "../../../../project/configuration";
+
+export interface IModelThumbnailRendererProps {
+	/**
+	 * The absolute path to the model file.
+	 */
+	absolutePath: string;
+	/**
+	 * The width of the thumbnail.
+	 */
+	width?: number;
+	/**
+	 * The height of the thumbnail.
+	 */
+	height?: number;
+	/**
+	 * Optional environment texture to use.
+	 */
+	environmentTexture?: CubeTexture;
+}
+
+export function ModelThumbnailRenderer(props: IModelThumbnailRendererProps) {
+	const canvasRef = useRef<HTMLCanvasElement>(null);
+	const { width = 120, height = 120 } = props;
+	const [loadError, setLoadError] = useState(false);
+
+	useEffect(() => {
+		if (!projectConfiguration.path || !canvasRef.current) {
+			return;
+		}
+
+		// Create engine with appropriate settings for thumbnails
+		const engine = new Engine(canvasRef.current, true, {
+			antialias: true,
+			audioEngine: false,
+			adaptToDeviceRatio: true,
+			preserveDrawingBuffer: true,
+			premultipliedAlpha: false,
+		});
+
+		const scene = new Scene(engine);
+		scene.clearColor.set(0, 0, 0, 0);
+
+		const camera = new ArcRotateCamera("camera", Math.PI / 4, Math.PI / 3, 20, Vector3.Zero(), scene);
+		camera.minZ = 0.1;
+		camera.fov = 0.8;
+
+		const dirLight = new DirectionalLight("dirLight", new Vector3(4, -4, -4), scene);
+		dirLight.intensity = 1;
+		dirLight.position = new Vector3(100, 100, 100);
+		dirLight.diffuse = new Color3(1, 1, 1);
+		dirLight.specular = new Color3(1, 1, 1);
+
+		const hemiLight = new HemisphericLight("hemiLight", new Vector3(0, 1, 0), scene);
+		hemiLight.intensity = 0.2;
+		hemiLight.diffuse = new Color3(1, 1, 1);
+		hemiLight.groundColor = new Color3(1, 1, 1);
+
+		if (props.environmentTexture) {
+			scene.environmentTexture = props.environmentTexture;
+		}
+
+		try {
+			const sceneRootUrl = dirname(props.absolutePath);
+			const fileName = basename(props.absolutePath);
+			
+			SceneLoader.AppendAsync(join(sceneRootUrl, "/"), fileName, scene).then(() => {
+				// Auto-adjust camera to focus on the model
+				scene.createDefaultCameraOrLight(false, true, true);
+				
+				// Center and scale the model to fit in the view
+				if (scene.meshes.length > 0) {
+					const boundingInfo = scene.meshes[0].getHierarchyBoundingVectors();
+					const center = Vector3.Center(boundingInfo.min, boundingInfo.max);
+					const radius = Vector3.Distance(boundingInfo.min, boundingInfo.max) / 2;
+					
+					camera.setTarget(center);
+					camera.radius = radius * 2;
+				}
+				
+				engine.runRenderLoop(() => {
+					scene.render();
+				});
+			}).catch((e) => {
+				console.error("Failed to load model:", e);
+				setLoadError(true);
+			});
+		} catch (e) {
+			console.error("Failed to load model:", e);
+			setLoadError(true);
+		}
+
+		// Cleanup
+		return () => {
+			engine.stopRenderLoop();
+			scene.dispose();
+			engine.dispose();
+		};
+	}, [props.absolutePath]);
+
+	if (loadError) {
+		return <BiSolidCube size="64px" />;
+	}
+
+	return <canvas ref={canvasRef} width={width} height={height} className="w-full h-full object-contain rounded-md" />;
+}


### PR DESCRIPTION
# Title
Add model preview

## Summary
Add model preview in the assets-browser

## Changes Made

### Add model thumbnail
- Modifies the model item to display the model thumbnail

## Benefits
- Quality of life, instead clicking in the object, you can see how it looks in the thumbnail. You can still access the preview window by double-clicking on it.

<img width="655" height="352" alt="Screenshot From 2025-08-23 14-01-33" src="https://github.com/user-attachments/assets/90010ec0-b320-439b-8f76-2bf7a400f4f2" />
