### PR TITLE
feat: add support of "multiline" parameter in @visibleAsString decorator in babylonjs-editor-tools

### DIFF
--- a/editor/src/editor/layout/inspector/fields/string.tsx
+++ b/editor/src/editor/layout/inspector/fields/string.tsx
@@ -1,4 +1,8 @@
 import { useState } from "react";
+import { MdOutlineInfo } from "react-icons/md";
+
+import { Textarea } from "../../../../ui/shadcn/ui/textarea";
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from "../../../../ui/shadcn/ui/tooltip";
 
 import { registerSimpleUndoRedo } from "../../../../tools/undoredo";
 import { getInspectorPropertyValue, setInspectorEffectivePropertyValue } from "../../../../tools/property";
@@ -6,6 +10,7 @@ import { getInspectorPropertyValue, setInspectorEffectivePropertyValue } from ".
 import { IEditorInspectorFieldProps } from "./field";
 
 export interface IEditorInspectorStringFieldProps extends IEditorInspectorFieldProps {
+	multiline?: boolean;
 	onChange?: (value: string) => void;
 }
 
@@ -13,35 +18,63 @@ export function EditorInspectorStringField(props: IEditorInspectorStringFieldPro
 	const [value, setValue] = useState<string>(getInspectorPropertyValue(props.object, props.property) ?? "");
 	const [oldValue, setOldValue] = useState<string>(getInspectorPropertyValue(props.object, props.property) ?? "");
 
+	function handleChange(newValue: string) {
+		setValue(newValue);
+		setInspectorEffectivePropertyValue(props.object, props.property, newValue);
+
+		props.onChange?.(newValue);
+	}
+
+	function handleBlur(newValue: string) {
+		if (newValue !== oldValue && !props.noUndoRedo) {
+			registerSimpleUndoRedo({
+				object: props.object,
+				property: props.property,
+
+				oldValue,
+				newValue: value,
+			});
+
+			setOldValue(newValue);
+		}
+	}
+
 	return (
 		<div className="flex gap-2 items-center px-2">
-			<div className="w-1/3 text-ellipsis overflow-hidden whitespace-nowrap">{props.label}</div>
+			<div className="flex items-center gap-2 w-1/3 text-ellipsis overflow-hidden whitespace-nowrap">
+				{props.label}
 
-			<input
-				type="text"
-				value={value}
-				onChange={(ev) => {
-					setValue(ev.currentTarget.value);
-					setInspectorEffectivePropertyValue(props.object, props.property, ev.currentTarget.value);
+				{props.tooltip && (
+					<TooltipProvider delayDuration={0}>
+						<Tooltip>
+							<TooltipTrigger>
+								<MdOutlineInfo size={24} />
+							</TooltipTrigger>
+							<TooltipContent className="bg-muted text-muted-foreground text-sm p-2">{props.tooltip}</TooltipContent>
+						</Tooltip>
+					</TooltipProvider>
+				)}
+			</div>
 
-					props.onChange?.(ev.currentTarget.value);
-				}}
-				onKeyUp={(ev) => ev.key === "Enter" && ev.currentTarget.blur()}
-				onBlur={(ev) => {
-					if (ev.currentTarget.value !== oldValue && !props.noUndoRedo) {
-						registerSimpleUndoRedo({
-							object: props.object,
-							property: props.property,
+			{!props.multiline && (
+				<input
+					type="text"
+					value={value}
+					onChange={(ev) => handleChange(ev.currentTarget.value)}
+					onKeyUp={(ev) => ev.key === "Enter" && ev.currentTarget.blur()}
+					onBlur={(ev) => handleBlur(ev.currentTarget.value)}
+					className="px-5 py-2 rounded-lg bg-black/50 text-white/75 outline-none w-2/3"
+				/>
+			)}
 
-							oldValue,
-							newValue: value,
-						});
-
-						setOldValue(ev.currentTarget.value);
-					}
-				}}
-				className="px-5 py-2 rounded-lg bg-black/50 text-white/75 outline-none w-2/3"
-			/>
+			{props.multiline && (
+				<Textarea
+					value={value}
+					onChange={(ev) => handleChange(ev.currentTarget.value)}
+					onBlur={(ev) => handleBlur(ev.currentTarget.value)}
+					className="px-5 py-2 rounded-lg bg-black/50 text-white/75 outline-none w-2/3"
+				/>
+			)}
 		</div>
 	);
 }

--- a/editor/src/editor/layout/inspector/script/field.tsx
+++ b/editor/src/editor/layout/inspector/script/field.tsx
@@ -13,7 +13,11 @@ import { XMarkIcon } from "@heroicons/react/20/solid";
 import { toast } from "sonner";
 
 import { Vector2, Vector3, Color3, Color4, Texture, CubeTexture } from "babylonjs";
-import { VisibleInInspectorDecoratorEntityConfiguration, VisibleInspectorDecoratorAssetConfiguration } from "babylonjs-editor-tools";
+import {
+	VisibleInInspectorDecoratorEntityConfiguration,
+	VisibleInInspectorDecoratorStringConfiguration,
+	VisibleInspectorDecoratorAssetConfiguration,
+} from "babylonjs-editor-tools";
 
 import { Editor } from "../../../main";
 
@@ -343,6 +347,7 @@ export function InspectorScriptField(props: IInspectorScriptFieldProps) {
 										property="value"
 										label={value.label ?? value.propertyKey}
 										tooltip={value.configuration.description}
+										multiline={(value.configuration as VisibleInInspectorDecoratorStringConfiguration).multiline}
 										onChange={() =>
 											applyValueToRunningSceneObject(props.editor, {
 												value,

--- a/editor/src/ui/shadcn/ui/textarea.tsx
+++ b/editor/src/ui/shadcn/ui/textarea.tsx
@@ -1,0 +1,19 @@
+import * as React from "react";
+
+import { cn } from "../../utils";
+
+const Textarea = React.forwardRef<HTMLTextAreaElement, React.ComponentProps<"textarea">>(({ className, ...props }, ref) => {
+	return (
+		<textarea
+			className={cn(
+				"flex min-h-[60px] w-full rounded-md border border-input bg-transparent px-3 py-2 text-base shadow-sm placeholder:text-muted-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:cursor-not-allowed disabled:opacity-50 md:text-sm",
+				className
+			)}
+			ref={ref}
+			{...props}
+		/>
+	);
+});
+Textarea.displayName = "Textarea";
+
+export { Textarea };

--- a/tools/src/decorators/inspector.ts
+++ b/tools/src/decorators/inspector.ts
@@ -31,6 +31,10 @@ export function visibleAsBoolean(label?: string, configuration?: Omit<VisibleInI
 	};
 }
 
+export type VisibleInInspectorDecoratorStringConfiguration = VisibleInInspectorDecoratorConfiguration & {
+	multiline?: boolean;
+};
+
 /**
  * Makes the decorated property visible in the editor inspector as a string.
  * The property can be customized per object in the editor and the custom value is applied
@@ -39,7 +43,7 @@ export function visibleAsBoolean(label?: string, configuration?: Omit<VisibleInI
  * @param label defines the optional label displayed in the inspector in the editor.
  * @param configuration defines the optional configuration for the field in the inspector (description, etc.).
  */
-export function visibleAsString(label?: string, configuration?: Omit<VisibleInInspectorDecoratorConfiguration, "type">) {
+export function visibleAsString(label?: string, configuration?: Omit<VisibleInInspectorDecoratorStringConfiguration, "type">) {
 	return function (target: any, propertyKey: string | Symbol) {
 		const ctor = target.constructor as ISceneDecoratorData;
 


### PR DESCRIPTION
#568
