### PR TITLE
fix: check for metadata in nodes before preloading script assets in babylonjs-editor-tools

### DIFF
--- a/tools/src/loading/script.ts
+++ b/tools/src/loading/script.ts
@@ -22,7 +22,7 @@ export async function _preloadScriptsAssets(scene: Scene, rootUrl: string) {
 	const nodes = [...scene.transformNodes, ...scene.meshes, ...scene.lights, ...scene.cameras];
 
 	const scripts = nodes
-		.filter((node) => node.metadata.scripts?.length)
+		.filter((node) => node.metadata?.scripts?.length)
 		.map((node) => node.metadata.scripts)
 		.flat();
 


### PR DESCRIPTION
#674