### PR TITLE
Add Default IDE/Editor Integration

### DIFF
--- a/editor/src/dashboard/item.tsx
+++ b/editor/src/dashboard/item.tsx
@@ -131,6 +131,11 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 		execNodePty(`code "${dirname(props.project.absolutePath)}"`);
 	}
 
+	function handleOpenInDefaultIde() {
+		const projectDir = dirname(props.project.absolutePath);
+		ipcRenderer.send("editor:open-with", projectDir);
+	}
+
 	return (
 		<ContextMenu onOpenChange={(o) => setContextMenuOpen(o)}>
 			<ContextMenuTrigger>
@@ -174,6 +179,9 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 											{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 										</DropdownMenuItem>
 										<DropdownMenuSeparator />
+										<DropdownMenuItem className="flex items-center gap-2" onClick={() => handleOpenInDefaultIde()}>
+											Open in Default IDE
+										</DropdownMenuItem>
 										<DropdownMenuItem className="flex items-center gap-2" onClick={() => handleOpenInVisualStudioCode()}>
 											Open in Visual Studio Code
 										</DropdownMenuItem>
@@ -219,6 +227,9 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 					{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 				</ContextMenuItem>
 				<ContextMenuSeparator />
+				<ContextMenuItem className="flex items-center gap-2" onClick={() => handleOpenInDefaultIde()}>
+					Open in Default IDE
+				</ContextMenuItem>
 				<ContextMenuItem className="flex items-center gap-2" onClick={() => handleOpenInVisualStudioCode()}>
 					Open in Visual Studio Code
 				</ContextMenuItem>

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -395,8 +395,6 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 
 		return (
 			<ContextMenuContent>
-			
-
 				{!this.state.isDirectory && (
 					<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:open-with", this.props.absolutePath)}>
 						Open
@@ -404,8 +402,8 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 				)}
 
 				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", this.props.absolutePath)}>
-						 {`Show in ${isDarwin ? "Finder" : "Explorer"}`}
-				</ContextMenuItem> 
+					{`Show in ${isDarwin ? "Finder" : "Explorer"}`}
+				</ContextMenuItem>
 
 				{items.map((item, index) => (
 					<Fragment key={`context-menu-item-${index}`}>{item}</Fragment>
@@ -429,8 +427,6 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 				<ContextMenuItem className="flex items-center gap-2 !text-red-400" onClick={() => this._handleTrashItem()}>
 					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Delete
 				</ContextMenuItem>
-
-
 			</ContextMenuContent>
 		);
 	}
@@ -448,8 +444,6 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 			console.error(e);
 		}
 	}
-
-    
 
 	private async _computePreviewImage(): Promise<void> {
 		const files = await readdir(this.props.absolutePath);

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -396,6 +396,12 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 					<ImFinder className="w-4 h-4" /> {`Show in ${isDarwin ? "Finder" : "Explorer"}`}
 				</ContextMenuItem>
 
+				{!this.state.isDirectory && (
+					<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:open-with", this.props.absolutePath)}>
+						Edit
+					</ContextMenuItem>
+				)}
+
 				<ContextMenuSeparator />
 
 				{items.map((item, index) => (
@@ -418,7 +424,7 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 				<ContextMenuSeparator />
 
 				<ContextMenuItem className="flex items-center gap-2 !text-red-400" onClick={() => this._handleTrashItem()}>
-					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Remove
+					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Delete
 				</ContextMenuItem>
 			</ContextMenuContent>
 		);
@@ -437,6 +443,8 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 			console.error(e);
 		}
 	}
+
+    
 
 	private async _computePreviewImage(): Promise<void> {
 		const files = await readdir(this.props.absolutePath);

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -250,7 +250,10 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 	 * Called on the item is double-clicked. To be overriden by the specialized items implementations.
 	 */
 	protected onDoubleClick(): void | Promise<void> {
-		// Nothing to do by default.
+		// If it's a file (not a directory), open it in the default editor
+		if (!this.state.isDirectory) {
+			ipcRenderer.send("editor:open-with", this.props.absolutePath);
+		}
 	}
 
 	private _handleDragStart(ev: DragEvent<HTMLDivElement>): void {

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -395,17 +395,17 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 
 		return (
 			<ContextMenuContent>
-				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", this.props.absolutePath)}>
-					<ImFinder className="w-4 h-4" /> {`Show in ${isDarwin ? "Finder" : "Explorer"}`}
-				</ContextMenuItem>
+			
 
 				{!this.state.isDirectory && (
 					<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:open-with", this.props.absolutePath)}>
-						Edit
+						Open
 					</ContextMenuItem>
 				)}
 
-				<ContextMenuSeparator />
+				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", this.props.absolutePath)}>
+						 {`Show in ${isDarwin ? "Finder" : "Explorer"}`}
+				</ContextMenuItem> 
 
 				{items.map((item, index) => (
 					<Fragment key={`context-menu-item-${index}`}>{item}</Fragment>
@@ -429,6 +429,8 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 				<ContextMenuItem className="flex items-center gap-2 !text-red-400" onClick={() => this._handleTrashItem()}>
 					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Delete
 				</ContextMenuItem>
+
+
 			</ContextMenuContent>
 		);
 	}

--- a/editor/src/editor/layout/toolbar.tsx
+++ b/editor/src/editor/layout/toolbar.tsx
@@ -90,6 +90,10 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 
 							<MenubarSeparator />
 
+							<MenubarItem disabled={!this.props.editor.state.projectPath} onClick={() => this._handleOpenInDefaultIde()}>
+								Open in Default IDE
+							</MenubarItem>
+
 							<MenubarItem disabled={!this.props.editor.state.visualStudioCodeAvailable} onClick={() => this._handleOpenVisualStudioCode()}>
 								Open in Visual Studio Code
 							</MenubarItem>
@@ -257,5 +261,14 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 
 		const p = await execNodePty(`code "${join(dirname(this.props.editor.state.projectPath), "/")}"`);
 		await p.wait();
+	}
+
+	private _handleOpenInDefaultIde(): void {
+		if (!this.props.editor.state.projectPath) {
+			return;
+		}
+
+		const projectDir = dirname(this.props.editor.state.projectPath);
+		ipcRenderer.send("editor:open-with", projectDir);
 	}
 }

--- a/editor/src/editor/layout/toolbar.tsx
+++ b/editor/src/editor/layout/toolbar.tsx
@@ -39,6 +39,7 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 		super(props);
 
 		ipcRenderer.on("editor:open-project", () => this._handleOpenProject());
+		ipcRenderer.on("editor:open-default-ide", () => this._handleOpenInDefaultIde());
 		ipcRenderer.on("editor:open-vscode", () => this._handleOpenVisualStudioCode());
 
 		this._nodeCommands = getNodeCommands(this.props.editor);

--- a/editor/src/editor/menu.ts
+++ b/editor/src/editor/menu.ts
@@ -56,6 +56,10 @@ export function setupEditorMenu(): void {
 						type: "separator",
 					},
 					{
+						label: "Open in Default IDE",
+						click: () => BrowserWindow.getFocusedWindow()?.webContents.send("editor:open-default-ide"),
+					},
+					{
 						label: "Open in Visual Studio Code",
 						click: () => BrowserWindow.getFocusedWindow()?.webContents.send("editor:open-vscode"),
 					},

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -66,13 +66,21 @@ async function openInIde(path: string, isDirectory: boolean): Promise<void> {
 		// On macOS, try JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA)
 		if (platform() === "darwin") {
 			exec(`open -a "PhpStorm" "${normalizedPath}"`, (error) => {
-				if (!error) return;
+				if (!error) {
+					return;
+				}
 				exec(`open -a "WebStorm" "${normalizedPath}"`, (error) => {
-					if (!error) return;
+					if (!error) {
+						return;
+					}
 					exec(`open -a "IntelliJ IDEA" "${normalizedPath}"`, (error) => {
-						if (!error) return;
+						if (!error) {
+							return;
+						}
 						exec(`open -a "IntelliJ IDEA CE" "${normalizedPath}"`, (error) => {
-							if (!error) return;
+							if (!error) {
+								return;
+							}
 							// Fallback to shell.openPath
 							shell.openPath(normalizedPath);
 						});

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -20,3 +20,17 @@ ipcMain.on("editor:show-item", (_, item) => {
 
 	shell.showItemInFolder(item);
 });
+
+ipcMain.on("editor:open-in-external-editor", (_, item) => {
+	const isWindows = platform() === "win32";
+	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
+
+	shell.openPath(item);
+});
+
+ipcMain.on("editor:open-with", (_, item) => {
+	const isWindows = platform() === "win32";
+	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
+
+	shell.openPath(item);
+});

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -1,5 +1,7 @@
 import { platform } from "os";
 import { ipcMain, shell } from "electron";
+import { exec } from "child_process";
+import { statSync } from "fs";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
 	const isWindows = platform() === "win32";
@@ -28,9 +30,102 @@ ipcMain.on("editor:open-in-external-editor", (_, item) => {
 	shell.openPath(item);
 });
 
-ipcMain.on("editor:open-with", (_, item) => {
-	const isWindows = platform() === "win32";
-	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
+async function checkCommandAvailable(command: string): Promise<boolean> {
+	return new Promise((resolve) => {
+		exec(`${command} --version`, (error) => {
+			resolve(!error);
+		});
+	});
+}
 
-	shell.openPath(item);
+async function openInIde(path: string, isDirectory: boolean): Promise<void> {
+	const isWindows = platform() === "win32";
+	const normalizedPath = isWindows ? path.replace(/\//g, "\\") : path.replace(/\\/g, "/");
+
+	if (isDirectory) {
+		// Try to open directory in IDEs
+		const ideCommands = [
+			{ command: "code", args: [normalizedPath] },
+			{ command: "cursor", args: [normalizedPath] },
+			{ command: "subl", args: [normalizedPath] }, // Sublime Text
+		];
+
+		// Try each IDE in order
+		for (const ide of ideCommands) {
+			if (await checkCommandAvailable(ide.command)) {
+				const fullCommand = `${ide.command} "${normalizedPath}"`;
+				exec(fullCommand, (error) => {
+					if (error) {
+						console.error(`Failed to open with ${ide.command}:`, error);
+					}
+				});
+				return;
+			}
+		}
+
+		// On macOS, try JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA)
+		if (platform() === "darwin") {
+			exec(`open -a "PhpStorm" "${normalizedPath}"`, (error) => {
+				if (!error) return;
+				exec(`open -a "WebStorm" "${normalizedPath}"`, (error) => {
+					if (!error) return;
+					exec(`open -a "IntelliJ IDEA" "${normalizedPath}"`, (error) => {
+						if (!error) return;
+						exec(`open -a "IntelliJ IDEA CE" "${normalizedPath}"`, (error) => {
+							if (!error) return;
+							// Fallback to shell.openPath
+							shell.openPath(normalizedPath);
+						});
+					});
+				});
+			});
+			return;
+		}
+
+		// On Windows, try JetBrains IDEs via CLI
+		if (isWindows) {
+			if (await checkCommandAvailable("phpstorm")) {
+				exec(`phpstorm "${normalizedPath}"`, (error) => {
+					if (error) {
+						console.error("Failed to open with PhpStorm:", error);
+					}
+				});
+				return;
+			}
+			if (await checkCommandAvailable("webstorm")) {
+				exec(`webstorm "${normalizedPath}"`, (error) => {
+					if (error) {
+						console.error("Failed to open with WebStorm:", error);
+					}
+				});
+				return;
+			}
+			if (await checkCommandAvailable("idea")) {
+				exec(`idea "${normalizedPath}"`, (error) => {
+					if (error) {
+						console.error("Failed to open with IntelliJ IDEA:", error);
+						shell.openPath(normalizedPath);
+					}
+				});
+				return;
+			}
+		}
+
+		// Fallback: open with default application
+		shell.openPath(normalizedPath);
+	} else {
+		// For files, use shell.openPath which uses OS default application
+		shell.openPath(normalizedPath);
+	}
+}
+
+ipcMain.on("editor:open-with", async (_, item) => {
+	try {
+		const stats = statSync(item);
+		const isDirectory = stats.isDirectory();
+		await openInIde(item, isDirectory);
+	} catch (e) {
+		// If stat fails, try as directory first, then as file
+		await openInIde(item, true);
+	}
 });


### PR DESCRIPTION
## Summary
Adds "Open in Default IDE/Editor" across the editor, enabling users to open files and project directories in their preferred IDE or the system default editor. Implements detection for VS Code, Cursor, Sublime Text, PhpStorm, WebStorm, and IntelliJ IDEA, trying available options in priority order. Also updates double-click to open files in the default editor.

## Changes Made

### External Editor Support for Files
- Added "Open" context menu item in the assets browser to open files with the OS default application
- Updated double-click behavior to open files in the default editor instead of no action
- Implemented IPC handler `editor:open-with` that uses Electron's `shell.openPath()` to respect OS file associations
- Moved "Show in Finder/Explorer" below the "Open" option in the context menu

### Default IDE Detection and Integration
- Implemented IDE detection that checks for available command-line tools (VS Code, Cursor, Sublime Text)
- Added support for JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA) on macOS and Windows
- Created priority-based IDE selection system that tries IDEs in order: VS Code → Cursor → Sublime Text → PhpStorm → WebStorm → IntelliJ IDEA
- Implemented fallback to system default application if no IDE is found

### UI Integration
- Added "Open in Default IDE" menu item in the File menu (before "Open in Visual Studio Code")
- Added "Open in Default IDE" option in the toolbar menu bar
- Added "Open in Default IDE" option in dashboard project item context and dropdown menus
- Maintained existing "Open in Visual Studio Code" functionality for explicit VS Code usage

### Technical Implementation
- Created `openInIde()` function in `shell.ts` that detects file vs directory and handles each appropriately
- Added `checkCommandAvailable()` helper function to verify IDE command-line tools are installed
- Implemented platform-specific handling for macOS (`open -a`) and Windows (CLI commands)
- Added proper error handling and fallback mechanisms

## Benefits
- Improves workflow by allowing users to quickly open files and projects in their preferred editor
- Reduces friction by automatically detecting and using available IDEs without manual configuration
- Supports multiple IDEs with smart detection, accommodating different preferences
- Consistent behavior across context menus, toolbar, and dashboard for predictable usage
- Better UX for file operations with double-click opening in the default editor
- Backward compatible: existing "Open in Visual Studio Code" remains available for explicit usage