### PR TITLE
Enable changing installation directory in NSIS config

### DIFF
--- a/build.mjs
+++ b/build.mjs
@@ -61,6 +61,7 @@ function build({ x64, arm64 } = options) {
 			},
 			nsis: {
 				oneClick: false,
+				allowToChangeInstallationDirectory: true,
 			},
 			linux: {
 				target: "AppImage",


### PR DESCRIPTION
## Summary
This pull request makes a small configuration improvement to the Windows installer build process. The change allows users to choose the installation directory during setup, rather than forcing a default location.

## Changes Made

### `allowToChangeInstallationDirectory`
Windows installer configuration: Enabled the option for users to change the installation directory by setting `allowToChangeInstallationDirectory: true` in the `nsis` section of the build configuration in `build.mjs`.

## Benefits
- It's able to change the installation directory.
