### PR TITLE
Add option to close dashboard when opening a project

### DIFF
--- a/editor/src/dashboard/create.tsx
+++ b/editor/src/dashboard/create.tsx
@@ -25,6 +25,7 @@ import { EditorProjectPackageManager, IEditorProject, EditorProjectTemplate } fr
 
 export interface IDashboardCreateProjectDialogProps {
 	isOpened: boolean;
+	closeDashboardOnProjectOpen: boolean;
 	onClose: () => void;
 }
 
@@ -101,7 +102,7 @@ export function DashboardCreateProjectDialog(props: IDashboardCreateProjectDialo
 			});
 
 			if (result) {
-				ipcRenderer.send("dashboard:open-project", projectAbsolutePath);
+				ipcRenderer.send("dashboard:open-project", projectAbsolutePath, props.closeDashboardOnProjectOpen);
 			}
 		} catch (e) {
 			showAlert("An unexpected error occured", e.message);

--- a/editor/src/dashboard/item.tsx
+++ b/editor/src/dashboard/item.tsx
@@ -27,7 +27,7 @@ import { DashboardProgressComponent } from "./progress";
 export interface IDashboardProjectItemProps {
 	isOpened: boolean;
 	project: ProjectType;
-
+	closeDashboardOnProjectOpen: boolean;
 	onRemove: () => void;
 }
 
@@ -127,6 +127,10 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 		setPlayingAddress("");
 	}
 
+	function handleLoadProject() {
+		ipcRenderer.send("dashboard:open-project", props.project.absolutePath, props.closeDashboardOnProjectOpen);
+	}
+
 	function handleOpenInVisualStudioCode() {
 		execNodePty(`code "${dirname(props.project.absolutePath)}"`);
 	}
@@ -135,7 +139,7 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 		<ContextMenu onOpenChange={(o) => setContextMenuOpen(o)}>
 			<ContextMenuTrigger>
 				<div
-					onDoubleClick={() => ipcRenderer.send("dashboard:open-project", props.project.absolutePath)}
+					onDoubleClick={handleLoadProject}
 					className={`
                         group
                         flex flex-col w-full rounded-lg cursor-pointer select-none
@@ -169,7 +173,7 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 										</Button>
 									</DropdownMenuTrigger>
 									<DropdownMenuContent>
-										<DropdownMenuItem onClick={() => ipcRenderer.send("dashboard:open-project", props.project.absolutePath)}>Open</DropdownMenuItem>
+										<DropdownMenuItem onClick={handleLoadProject}>Open</DropdownMenuItem>
 										<DropdownMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", props.project.absolutePath)}>
 											{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 										</DropdownMenuItem>
@@ -214,7 +218,7 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 				</div>
 			</ContextMenuTrigger>
 			<ContextMenuContent>
-				<ContextMenuItem onClick={() => ipcRenderer.send("dashboard:open-project", props.project.absolutePath)}>Open</ContextMenuItem>
+				<ContextMenuItem onClick={handleLoadProject}>Open</ContextMenuItem>
 				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", props.project.absolutePath)}>
 					{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 				</ContextMenuItem>

--- a/editor/src/index.ts
+++ b/editor/src/index.ts
@@ -107,9 +107,20 @@ async function openDashboard(): Promise<void> {
 	dashboardWindow.focus();
 }
 
-ipcMain.on("dashboard:open-project", (_, file) => {
+function closeDashboard(): void {
+	if (dashboardWindow) {
+		dashboardWindow.close();
+		dashboardWindow = null;
+	}
+}
+
+ipcMain.on("dashboard:open-project", (_, file: string, shouldCloseDashboard?: boolean) => {
 	openProject(file);
 	dashboardWindow?.minimize();
+
+	if (shouldCloseDashboard) {
+		closeDashboard();
+	}
 });
 
 ipcMain.on("dashboard:update-projects", () => {
@@ -138,7 +149,7 @@ async function openProject(filePath: string): Promise<void> {
 		notifyWindows("dashboard:opened-projects", openedProjects);
 
 		if (openedProjects.length === 0) {
-			dashboardWindow?.restore();
+			openDashboard();
 		}
 	});
 

--- a/editor/src/tools/local-storage.ts
+++ b/editor/src/tools/local-storage.ts
@@ -54,12 +54,35 @@ export function tryGetExperimentalFeaturesEnabledFromLocalStorage(): boolean {
 }
 
 /**
- * Sets wether or not experimental features are enabled in the local storage.
+ * Sets whether or not experimental features are enabled in the local storage.
  * @param enabled defines wether or not experimental features are enabled.
  */
 export function trySetExperimentalFeaturesEnabledInLocalStorage(enabled: boolean): void {
 	try {
 		localStorage.setItem("editor-experimental-features", JSON.stringify(enabled));
+	} catch (e) {
+		// Catch silently.
+	}
+}
+
+/**
+ * Returns wether or not the dashboard should be closed when a project is opened.
+ */
+export function tryGetCloseDashboardOnProjectOpenFromLocalStorage(): boolean {
+	try {
+		return localStorage.getItem("babylonjs-editor-close-dashboard-on-project-open") === "true";
+	} catch (e) {
+		return false;
+	}
+}
+
+/**
+ * Sets whether or not the dashboard should be closed when a project is opened.
+ * @param enabled defines whether or not the dashboard should be closed when a project is opened.
+ */
+export function trySetCloseDashboardOnProjectOpenInLocalStorage(enabled: boolean): void {
+	try {
+		localStorage.setItem("babylonjs-editor-close-dashboard-on-project-open", JSON.stringify(enabled));
 	} catch (e) {
 		// Catch silently.
 	}


### PR DESCRIPTION
## Summary
- Adds a “Keep Dashboard Open” option to the dashboard panel.
When enabled, the dashboard remains open when starting a project, matching the current behavior.
When disabled, the dashboard automatically closes when a project is opened, and reopens once the project is closed.

## Changes Made

### Dashboard UI
- Added a switch option with a tooltip, positioned at the bottom-right corner.
<img width="1041" height="773" alt="Screenshot From 2025-11-11 22-07-14" src="https://github.com/user-attachments/assets/20b87f04-60e9-4ca7-b930-e8878dd3fe4a" />
<img width="1041" height="773" alt="Screenshot From 2025-11-11 22-11-11" src="https://github.com/user-attachments/assets/7d564f5b-bdf6-4d87-9e3e-f89c9f7a128e" />

- Additionally, fixed top controls layout issues when scrolling and ensured the entire top bar remains fixed.
Before:
https://github.com/user-attachments/assets/316ba798-f4e3-4132-ae8f-0eaa42360e5d
After:
https://github.com/user-attachments/assets/031ec86b-40a9-436e-9288-57aad4b89c86


### Saving
- Implemented persistence logic so the chosen setting is stored and restored on next launch.
- Setting is saved automatically when the user updates the option.

## Benefits
- Improves usability and customization of dashboard behavior.
