### PR TITLE
Avoid duplicated console log keys to prevent render looping

### DIFF
--- a/editor/src/editor/layout/console.tsx
+++ b/editor/src/editor/layout/console.tsx
@@ -8,6 +8,7 @@ import { Editor } from "../main";
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger } from "../../ui/shadcn/ui/context-menu";
 
 import { EditorConsoleProgressLogComponent } from "./console/progress-log";
+import { UniqueNumber } from "../../tools/tools";
 
 export interface IEditorConsoleProps {
 	editor: Editor;
@@ -49,11 +50,7 @@ export class EditorConsole extends Component<IEditorConsoleProps, IEditorConsole
 	 * @param message defines the message to log.
 	 */
 	public log(message: ReactNode): void {
-		this._addLog(
-			<div key={this.state.logs.length + 1} className="whitespace-break-spaces hover:bg-secondary/50 transition-all duration-300 ease-in-out">
-				{message}
-			</div>
-		);
+		this._addLog(<div className="whitespace-break-spaces hover:bg-secondary/50 transition-all duration-300 ease-in-out">{message}</div>);
 	}
 
 	/**
@@ -61,11 +58,7 @@ export class EditorConsole extends Component<IEditorConsoleProps, IEditorConsole
 	 * @param message defines the message to log.
 	 */
 	public warn(message: ReactNode): void {
-		this._addLog(
-			<div key={this.state.logs.length + 1} className="whitespace-break-spaces !text-yellow-500 hover:bg-secondary/50 transition-all duration-300 ease-in-out">
-				{message}
-			</div>
-		);
+		this._addLog(<div className="whitespace-break-spaces !text-yellow-500 hover:bg-secondary/50 transition-all duration-300 ease-in-out">{message}</div>);
 	}
 
 	/**
@@ -73,11 +66,7 @@ export class EditorConsole extends Component<IEditorConsoleProps, IEditorConsole
 	 * @param message defines the message to log.
 	 */
 	public error(message: ReactNode): void {
-		this._addLog(
-			<div key={this.state.logs.length + 1} className="whitespace-break-spaces !text-red-500 hover:bg-secondary/50 transition-all duration-300 ease-in-out">
-				{message}
-			</div>
-		);
+		this._addLog(<div className="whitespace-break-spaces !text-red-500 hover:bg-secondary/50 transition-all duration-300 ease-in-out">{message}</div>);
 	}
 
 	/**
@@ -101,7 +90,7 @@ export class EditorConsole extends Component<IEditorConsoleProps, IEditorConsole
 		let ref: HTMLDivElement | null = null;
 
 		this.state.logs.push(
-			<ContextMenu key={`log-${this.state.logs.length}`}>
+			<ContextMenu key={`log-${UniqueNumber.Get()}`}>
 				<ContextMenuTrigger>
 					<div ref={(r) => (ref = r)}>{log}</div>
 				</ContextMenuTrigger>


### PR DESCRIPTION
## Summary
Fixes an issue in the Editor console where log entries could receive duplicated React keys.
The previous implementation used `logs.length` to generate keys, but since the console truncates the list at 1000 items, the length would produce repeated keys. As a result, React entered an infinite render loop, causing the application to freeze and become unresponsive.

https://github.com/user-attachments/assets/f33bbfad-8e12-4156-bbdf-7353e15522a5

In this preview, I temporarily changed the truncation limit to 20 items just to speed up the reproduction of the bug.

## Changes Made

### Console component
- Replaced the length-based key generation with UniqueNumber.Get() to ensure keys are always unique.
- Removed redundant key props from nested elements (which had no effect and contributed to instability).

## Benefits
- Prevents application freeze after the 1,000th log.
