### PR TITLE
chore: Fix hot reload

### DIFF
--- a/cli/package.json
+++ b/cli/package.json
@@ -14,7 +14,7 @@
 	},
 	"exports": {
 		".": {
-			"types": "./declaration/src/export.d.ts",
+			"types": "./declaration/src/export.d.mts",
 			"import": "./build/src/export.mjs",
 			"require": "./build/index.node.js"
 		}

--- a/editor/package.json
+++ b/editor/package.json
@@ -10,12 +10,13 @@
 		"url": "https://twitter.com/luaacro"
 	},
 	"scripts": {
-		"postinstall": "rimraf --glob ./node_modules/babylonjs-editor-tools ./node_modules/babylonjs-editor-cli",
 		"build": "tsc -p . && tailwindcss -i ./index.css -o ./build/index.css && node esbuild.mjs",
 		"watch": "concurrently -i \"tsc -p . --watch\" \"node esbuild.mjs --watch\" -c bgYellow.bold,bgBlue.bold --names editor-ts,editor-dependencies",
 		"watch-css": "tailwindcss -i ./index.css -o ./build/index.css --watch",
 		"watch-all": "concurrently \"yarn watch\" \"yarn watch-css\" \"node esbuild.mjs --watch\" -c bgYellow.bold,bgBlue.bold,bgGreen.bold --names editor-ts,editor-css,editor-dependencies",
 		"start": "electron .",
+		"dev": "yarn workspace babylonjs-editor-tools build && yarn workspace babylonjs-editor-cli build && yarn build && concurrently -n watch,electron -c yellow,blue \"yarn watch\" \"electron .\"",
+		"dev:all": "yarn workspace babylonjs-editor-tools build && yarn workspace babylonjs-editor-cli build && yarn build && concurrently -n watch,watch-css,electron -c yellow,green,blue \"yarn watch\" \"yarn watch-css\" \"electron .\"",
 		"test": "vitest run",
 		"watch-test": "vitest --watch",
 		"coverage": "vitest run --coverage"

--- a/package.json
+++ b/package.json
@@ -43,6 +43,8 @@
 		"build-all": "yarn build && yarn build-templates && yarn build-website",
 		"build-all-concurrently": "concurrently \"yarn build-tools\" \"yarn build-cli\" -c bgYellow.bold,bgBlue.bold --names tools,cli && yarn build-editor && concurrently \"yarn workspace babylonjs-editor-plugins build-concurrently\" \"yarn workspace babylonjs-editor-templates build-concurrently\" \"yarn workspace babylonjs-editor-website build\" -c bgYellow.bold,bgBlue.bold,bgGreen.bold --names plugins,templates,website",
 		"start": "yarn workspace babylonjs-editor start",
+		"dev": "yarn workspace babylonjs-editor dev",
+		"dev:all": "yarn workspace babylonjs-editor dev:all",
 		"package": "yarn clean && yarn clean:node_modules && yarn && yarn lint && yarn build-all-concurrently && yarn test && node build.mjs",
 		"clean": "rimraf editor/build editor/declaration editor/electron-packages editor/coverage tools/build tools/declaration tools/coverage website/.next cli/build cli/declaration && yarn workspace babylonjs-editor-plugins clean && yarn workspace babylonjs-editor-templates clean",
 		"clean:node_modules": "rm -rf editor/node_modules tools/node_modules plugins/**/node_modules templates/**/node_modules website/node_modules node_modules",


### PR DESCRIPTION
# Title
Fix hot reload

## Summary
I am not sure if it's working for other people but the changes I make in the code, only appears when I rebuild the project. Adding watch, I can simply run `yarn dev` and the hot reload works for me.

## Changes Made

- Add `dev` and `dev:all` to run tools+cli build then watch with Electron.
- Forward `yarn dev` from repo root.
- Remove postinstall rimraf of workspace packages.
- Point CLI package types to generated export.d.mts.

## Benefits
Changes in the code make effect on the fly