### PR TITLE
Open in Default IDE" action with configurable Default IDE preferenceFileitem action feauture

### DIFF
--- a/editor/src/dashboard/item.tsx
+++ b/editor/src/dashboard/item.tsx
@@ -20,7 +20,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 
 import { isDarwin } from "../tools/os";
 import { ProjectType } from "../tools/project";
-import { tryGetDefaultIdeFromLocalStorage } from "../tools/local-storage";
+import { openInIde } from "../tools/ide";
 import { execNodePty, NodePtyInstance } from "../tools/node-pty";
 
 import { IEditorProject } from "../project/typings";
@@ -145,7 +145,7 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 
 	function handleOpenInDefaultIde() {
 		const projectDir = dirname(props.project.absolutePath);
-		ipcRenderer.send("editor:open-with", projectDir, tryGetDefaultIdeFromLocalStorage());
+		openInIde(projectDir, true);
 	}
 
 	return (

--- a/editor/src/dashboard/item.tsx
+++ b/editor/src/dashboard/item.tsx
@@ -20,6 +20,7 @@ import { DropdownMenu, DropdownMenuContent, DropdownMenuItem, DropdownMenuSepara
 
 import { isDarwin } from "../tools/os";
 import { ProjectType } from "../tools/project";
+import { tryGetDefaultIdeFromLocalStorage } from "../tools/local-storage";
 import { execNodePty, NodePtyInstance } from "../tools/node-pty";
 
 import { IEditorProject } from "../project/typings";
@@ -142,6 +143,11 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 		execNodePty(`code "${dirname(props.project.absolutePath)}"`);
 	}
 
+	function handleOpenInDefaultIde() {
+		const projectDir = dirname(props.project.absolutePath);
+		ipcRenderer.send("editor:open-with", projectDir, tryGetDefaultIdeFromLocalStorage());
+	}
+
 	return (
 		<ContextMenu onOpenChange={(o) => setContextMenuOpen(o)}>
 			<ContextMenuTrigger>
@@ -185,6 +191,9 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 											{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 										</DropdownMenuItem>
 										<DropdownMenuSeparator />
+										<DropdownMenuItem className="flex items-center gap-2" onClick={() => handleOpenInDefaultIde()}>
+											Open in Default IDE
+										</DropdownMenuItem>
 										<DropdownMenuItem className="flex items-center gap-2" onClick={() => handleOpenInVisualStudioCode()}>
 											Open in Visual Studio Code
 										</DropdownMenuItem>
@@ -237,6 +246,9 @@ export function DashboardProjectItem(props: IDashboardProjectItemProps) {
 					{`Show in ${isDarwin() ? "Finder" : "Explorer"}`}
 				</ContextMenuItem>
 				<ContextMenuSeparator />
+				<ContextMenuItem className="flex items-center gap-2" onClick={() => handleOpenInDefaultIde()}>
+					Open in Default IDE
+				</ContextMenuItem>
 				<ContextMenuItem className="flex items-center gap-2" onClick={() => handleOpenInVisualStudioCode()}>
 					Open in Visual Studio Code
 				</ContextMenuItem>

--- a/editor/src/editor/dialogs/edit-preferences/edit-preferences.tsx
+++ b/editor/src/editor/dialogs/edit-preferences/edit-preferences.tsx
@@ -7,7 +7,12 @@ import { Separator } from "../../../ui/shadcn/ui/separator";
 import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from "../../../ui/shadcn/ui/select";
 import { AlertDialog, AlertDialogCancel, AlertDialogContent, AlertDialogFooter, AlertDialogHeader, AlertDialogTitle } from "../../../ui/shadcn/ui/alert-dialog";
 
-import { trySetExperimentalFeaturesEnabledInLocalStorage } from "../../../tools/local-storage";
+import {
+	defaultIdeOptions,
+	tryGetDefaultIdeFromLocalStorage,
+	trySetDefaultIdeInLocalStorage,
+	trySetExperimentalFeaturesEnabledInLocalStorage,
+} from "../../../tools/local-storage";
 
 import { EditorInspectorKeyField } from "../../layout/inspector/fields/key";
 import { EditorInspectorNumberField } from "../../layout/inspector/fields/number";
@@ -28,6 +33,7 @@ export interface IEditorEditPreferencesComponentProps {
 
 export interface IEditorEditPreferencesComponentState {
 	theme: "light" | "dark";
+	defaultIde: string;
 }
 
 export class EditorEditPreferencesComponent extends Component<IEditorEditPreferencesComponentProps, IEditorEditPreferencesComponentState> {
@@ -36,6 +42,7 @@ export class EditorEditPreferencesComponent extends Component<IEditorEditPrefere
 
 		this.state = {
 			theme: document.body.classList.contains("dark") ? "dark" : "light",
+			defaultIde: tryGetDefaultIdeFromLocalStorage(),
 		};
 	}
 
@@ -50,6 +57,8 @@ export class EditorEditPreferencesComponent extends Component<IEditorEditPrefere
 					<div className="flex flex-col gap-[20px]">
 						<Separator />
 						{this._getThemesComponent()}
+						<Separator />
+						{this._getDefaultIdeComponent()}
 						<Separator />
 						{this._getCameraControlPreferences()}
 						<Separator />
@@ -89,6 +98,34 @@ export class EditorEditPreferencesComponent extends Component<IEditorEditPrefere
 						<SelectContent>
 							<SelectItem value="light">Light</SelectItem>
 							<SelectItem value="dark">Dark</SelectItem>
+						</SelectContent>
+					</Select>
+				</div>
+			</div>
+		);
+	}
+
+	private _getDefaultIdeComponent(): ReactNode {
+		return (
+			<div className="flex flex-col gap-[10px] w-full">
+				<div className="flex flex-col gap-[10px]">
+					<Label className="text-xl font-[400]">Default IDE</Label>
+					<Select
+						value={this.state.defaultIde}
+						onValueChange={(v) => {
+							this.setState({ defaultIde: v });
+							trySetDefaultIdeInLocalStorage(v);
+						}}
+					>
+						<SelectTrigger className="">
+							<SelectValue placeholder="Select Value..." />
+						</SelectTrigger>
+						<SelectContent>
+							{defaultIdeOptions.map((option) => (
+								<SelectItem key={option.id} value={option.id}>
+									{option.label}
+								</SelectItem>
+							))}
 						</SelectContent>
 					</Select>
 				</div>

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -26,7 +26,7 @@ import { Input } from "../../../../ui/shadcn/ui/input";
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, ContextMenuSeparator } from "../../../../ui/shadcn/ui/context-menu";
 
 import { isDarwin } from "../../../../tools/os";
-import { tryGetDefaultIdeFromLocalStorage } from "../../../../tools/local-storage";
+import { openInIde } from "../../../../tools/ide";
 
 import { Editor } from "../../../main";
 
@@ -252,7 +252,7 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 	protected onDoubleClick(): void | Promise<void> {
 		// If it's a file (not a directory), open it in the default editor
 		if (!this.state.isDirectory) {
-			ipcRenderer.send("editor:open-with", this.props.absolutePath, tryGetDefaultIdeFromLocalStorage());
+			openInIde(this.props.absolutePath, false);
 		}
 	}
 
@@ -396,7 +396,7 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 		return (
 			<ContextMenuContent>
 				{!this.state.isDirectory && (
-					<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:open-with", this.props.absolutePath, tryGetDefaultIdeFromLocalStorage())}>
+					<ContextMenuItem className="flex items-center gap-2" onClick={() => openInIde(this.props.absolutePath, false)}>
 						Open
 					</ContextMenuItem>
 				)}

--- a/editor/src/editor/layout/assets-browser/items/item.tsx
+++ b/editor/src/editor/layout/assets-browser/items/item.tsx
@@ -12,7 +12,6 @@ import { Grid } from "react-loader-spinner";
 
 import { toast } from "sonner";
 
-import { ImFinder } from "react-icons/im";
 import { BiSolidFileCss } from "react-icons/bi";
 import { GiCeilingLight } from "react-icons/gi";
 import { GrStatusUnknown } from "react-icons/gr";
@@ -27,6 +26,7 @@ import { Input } from "../../../../ui/shadcn/ui/input";
 import { ContextMenu, ContextMenuContent, ContextMenuItem, ContextMenuTrigger, ContextMenuSeparator } from "../../../../ui/shadcn/ui/context-menu";
 
 import { isDarwin } from "../../../../tools/os";
+import { tryGetDefaultIdeFromLocalStorage } from "../../../../tools/local-storage";
 
 import { Editor } from "../../../main";
 
@@ -250,7 +250,10 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 	 * Called on the item is double-clicked. To be overriden by the specialized items implementations.
 	 */
 	protected onDoubleClick(): void | Promise<void> {
-		// Nothing to do by default.
+		// If it's a file (not a directory), open it in the default editor
+		if (!this.state.isDirectory) {
+			ipcRenderer.send("editor:open-with", this.props.absolutePath, tryGetDefaultIdeFromLocalStorage());
+		}
 	}
 
 	private _handleDragStart(ev: DragEvent<HTMLDivElement>): void {
@@ -392,11 +395,15 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 
 		return (
 			<ContextMenuContent>
-				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", this.props.absolutePath)}>
-					<ImFinder className="w-4 h-4" /> {`Show in ${isDarwin ? "Finder" : "Explorer"}`}
-				</ContextMenuItem>
+				{!this.state.isDirectory && (
+					<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:open-with", this.props.absolutePath, tryGetDefaultIdeFromLocalStorage())}>
+						Open
+					</ContextMenuItem>
+				)}
 
-				<ContextMenuSeparator />
+				<ContextMenuItem className="flex items-center gap-2" onClick={() => ipcRenderer.send("editor:show-item", this.props.absolutePath)}>
+					{`Show in ${isDarwin ? "Finder" : "Explorer"}`}
+				</ContextMenuItem>
 
 				{items.map((item, index) => (
 					<Fragment key={`context-menu-item-${index}`}>{item}</Fragment>
@@ -418,7 +425,7 @@ export class AssetsBrowserItem extends Component<IAssetsBrowserItemProps, IAsset
 				<ContextMenuSeparator />
 
 				<ContextMenuItem className="flex items-center gap-2 !text-red-400" onClick={() => this._handleTrashItem()}>
-					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Remove
+					<AiOutlineClose className="w-5 h-5" fill="rgb(248, 113, 113)" /> Delete
 				</ContextMenuItem>
 			</ContextMenuContent>
 		);

--- a/editor/src/editor/layout/toolbar.tsx
+++ b/editor/src/editor/layout/toolbar.tsx
@@ -19,6 +19,7 @@ import {
 } from "../../ui/shadcn/ui/menubar";
 
 import { isDarwin } from "../../tools/os";
+import { tryGetDefaultIdeFromLocalStorage } from "../../tools/local-storage";
 import { execNodePty } from "../../tools/node-pty";
 import { openSingleFileDialog } from "../../tools/dialog";
 import { saveSceneScreenshot } from "../../tools/scene/screenshot";
@@ -55,6 +56,7 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 		super(props);
 
 		ipcRenderer.on("editor:open-project", () => this._handleOpenProject());
+		ipcRenderer.on("editor:open-default-ide", () => this._handleOpenInDefaultIde());
 		ipcRenderer.on("editor:open-vscode", () => this._handleOpenVisualStudioCode());
 		ipcRenderer.on("editor:toggle-marketplace", () => this._handleToggleMarketplace());
 
@@ -109,6 +111,10 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 							<MenubarItem onClick={() => this.props.editor.setState({ generateProject: true })}>Generate All Scenes and Assets...</MenubarItem>
 
 							<MenubarSeparator />
+
+							<MenubarItem disabled={!this.props.editor.state.projectPath} onClick={() => this._handleOpenInDefaultIde()}>
+								Open in Default IDE
+							</MenubarItem>
 
 							<MenubarItem disabled={!this.props.editor.state.visualStudioCodeAvailable} onClick={() => this._handleOpenVisualStudioCode()}>
 								Open in Visual Studio Code
@@ -312,6 +318,15 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 
 		const p = await execNodePty(`code "${join(dirname(this.props.editor.state.projectPath), "/")}"`);
 		await p.wait();
+	}
+
+	private _handleOpenInDefaultIde(): void {
+		if (!this.props.editor.state.projectPath) {
+			return;
+		}
+
+		const projectDir = dirname(this.props.editor.state.projectPath);
+		ipcRenderer.send("editor:open-with", projectDir, tryGetDefaultIdeFromLocalStorage());
 	}
 
 	private _handleToggleMarketplace(): void {

--- a/editor/src/editor/layout/toolbar.tsx
+++ b/editor/src/editor/layout/toolbar.tsx
@@ -19,7 +19,7 @@ import {
 } from "../../ui/shadcn/ui/menubar";
 
 import { isDarwin } from "../../tools/os";
-import { tryGetDefaultIdeFromLocalStorage } from "../../tools/local-storage";
+import { openInIde } from "../../tools/ide";
 import { execNodePty } from "../../tools/node-pty";
 import { openSingleFileDialog } from "../../tools/dialog";
 import { saveSceneScreenshot } from "../../tools/scene/screenshot";
@@ -326,7 +326,7 @@ export class EditorToolbar extends Component<IEditorToolbarProps> {
 		}
 
 		const projectDir = dirname(this.props.editor.state.projectPath);
-		ipcRenderer.send("editor:open-with", projectDir, tryGetDefaultIdeFromLocalStorage());
+		openInIde(projectDir, true);
 	}
 
 	private _handleToggleMarketplace(): void {

--- a/editor/src/editor/menu.ts
+++ b/editor/src/editor/menu.ts
@@ -63,6 +63,10 @@ export function setupEditorMenu(options: { enableExperimentalFeatures: boolean; 
 						type: "separator",
 					},
 					{
+						label: "Open in Default IDE",
+						click: () => BrowserWindow.getFocusedWindow()?.webContents.send("editor:open-default-ide"),
+					},
+					{
 						label: "Open in Visual Studio Code",
 						click: () => BrowserWindow.getFocusedWindow()?.webContents.send("editor:open-vscode"),
 					},

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -1,5 +1,8 @@
 import { platform } from "os";
 import { ipcMain, shell } from "electron";
+import { statSync } from "fs";
+
+import { executeAsync } from "../../tools/process";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
 	const isWindows = platform() === "win32";
@@ -19,4 +22,136 @@ ipcMain.on("editor:show-item", (_, item) => {
 	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
 
 	shell.showItemInFolder(item);
+});
+
+ipcMain.on("editor:open-in-external-editor", (_, item) => {
+	const isWindows = platform() === "win32";
+	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
+
+	shell.openPath(item);
+});
+
+/**
+ * Runs the given command using `executeAsync` (which also fixes the PATH on macOS so CLI tools
+ * launched from the bundled app can be resolved). Resolves true on success, false otherwise.
+ */
+async function runCommand(command: string): Promise<boolean> {
+	try {
+		await executeAsync(command);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+/**
+ * Returns wether or not the given CLI command is available on the system.
+ */
+async function checkCommandAvailable(command: string): Promise<boolean> {
+	return runCommand(`${command} --version`);
+}
+
+/**
+ * Defines for each supported IDE identifier the CLI command and the macOS application name
+ * used to launch it. Identifiers must match the ones exposed in the editor preferences.
+ */
+const ideLaunchers: Record<string, { cli: string; macApp?: string }> = {
+	code: { cli: "code", macApp: "Visual Studio Code" },
+	cursor: { cli: "cursor", macApp: "Cursor" },
+	subl: { cli: "subl", macApp: "Sublime Text" },
+	phpstorm: { cli: "phpstorm", macApp: "PhpStorm" },
+	webstorm: { cli: "webstorm", macApp: "WebStorm" },
+	idea: { cli: "idea", macApp: "IntelliJ IDEA" },
+};
+
+/**
+ * Tries to open the given path with the IDE matching the given identifier.
+ * Returns true when the IDE could be launched, false otherwise.
+ */
+async function tryLaunchIde(ide: string, normalizedPath: string): Promise<boolean> {
+	const launcher = ideLaunchers[ide];
+	if (!launcher) {
+		return false;
+	}
+
+	// Prefer the CLI command when available (works on all platforms).
+	if (await checkCommandAvailable(launcher.cli)) {
+		if (await runCommand(`${launcher.cli} "${normalizedPath}"`)) {
+			return true;
+		}
+	}
+
+	// On macOS, fallback to launching the application by its name.
+	if (platform() === "darwin" && launcher.macApp) {
+		return runCommand(`open -a "${launcher.macApp}" "${normalizedPath}"`);
+	}
+
+	return false;
+}
+
+async function openInIde(path: string, isDirectory: boolean, ide?: string): Promise<void> {
+	const isWindows = platform() === "win32";
+	const normalizedPath = isWindows ? path.replace(/\//g, "\\") : path.replace(/\\/g, "/");
+
+	// Open with the system default application when explicitly requested.
+	if (ide === "system") {
+		shell.openPath(normalizedPath);
+		return;
+	}
+
+	// When a specific IDE is selected in the preferences, try it first.
+	if (ide && ide !== "auto" && ideLaunchers[ide]) {
+		if (await tryLaunchIde(ide, normalizedPath)) {
+			return;
+		}
+		// Fall through to auto-detection if the selected IDE could not be launched.
+	}
+
+	if (isDirectory) {
+		// Try to open the directory in one of the CLI-based IDEs (works on all platforms).
+		for (const command of ["code", "cursor", "subl"]) {
+			if (await checkCommandAvailable(command)) {
+				if (await runCommand(`${command} "${normalizedPath}"`)) {
+					return;
+				}
+			}
+		}
+
+		// On macOS, try JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA).
+		if (platform() === "darwin") {
+			for (const app of ["PhpStorm", "WebStorm", "IntelliJ IDEA", "IntelliJ IDEA CE"]) {
+				if (await runCommand(`open -a "${app}" "${normalizedPath}"`)) {
+					return;
+				}
+			}
+		}
+
+		// On Windows, try JetBrains IDEs via CLI.
+		if (isWindows) {
+			for (const command of ["phpstorm", "webstorm", "idea"]) {
+				if (await checkCommandAvailable(command)) {
+					if (await runCommand(`${command} "${normalizedPath}"`)) {
+						return;
+					}
+				}
+			}
+		}
+
+		// Fallback: open with default application.
+		shell.openPath(normalizedPath);
+	} else {
+		// For files, use shell.openPath which uses OS default application.
+		shell.openPath(normalizedPath);
+	}
+}
+
+ipcMain.on("editor:open-with", async (_, item, ide) => {
+	try {
+		const stats = statSync(item);
+		const isDirectory = stats.isDirectory();
+		await openInIde(item, isDirectory, ide);
+	} catch (e) {
+		// If stat fails, try as directory first, then as file
+		await openInIde(item, true, ide);
+	}
 });

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -1,8 +1,5 @@
 import { platform } from "os";
 import { ipcMain, shell } from "electron";
-import { statSync } from "fs";
-
-import { openInIde } from "../../tools/ide";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
 	const isWindows = platform() === "win32";
@@ -29,15 +26,4 @@ ipcMain.on("editor:open-in-external-editor", (_, item) => {
 	item = isWindows ? item.replace(/\//g, "\\") : item.replace(/\\/g, "/");
 
 	shell.openPath(item);
-});
-
-ipcMain.on("editor:open-with", async (_, item, ide) => {
-	try {
-		const stats = statSync(item);
-		const isDirectory = stats.isDirectory();
-		await openInIde(item, isDirectory, ide);
-	} catch (e) {
-		// If stat fails, try as directory first, then as file
-		await openInIde(item, true, ide);
-	}
 });

--- a/editor/src/electron/events/shell.ts
+++ b/editor/src/electron/events/shell.ts
@@ -2,7 +2,7 @@ import { platform } from "os";
 import { ipcMain, shell } from "electron";
 import { statSync } from "fs";
 
-import { executeAsync } from "../../tools/process";
+import { openInIde } from "../../tools/ide";
 
 ipcMain.on("editor:trash-items", async (ev, items) => {
 	const isWindows = platform() === "win32";
@@ -30,120 +30,6 @@ ipcMain.on("editor:open-in-external-editor", (_, item) => {
 
 	shell.openPath(item);
 });
-
-/**
- * Runs the given command using `executeAsync` (which also fixes the PATH on macOS so CLI tools
- * launched from the bundled app can be resolved). Resolves true on success, false otherwise.
- */
-async function runCommand(command: string): Promise<boolean> {
-	try {
-		await executeAsync(command);
-		return true;
-	} catch (e) {
-		return false;
-	}
-}
-
-/**
- * Returns wether or not the given CLI command is available on the system.
- */
-async function checkCommandAvailable(command: string): Promise<boolean> {
-	return runCommand(`${command} --version`);
-}
-
-/**
- * Defines for each supported IDE identifier the CLI command and the macOS application name
- * used to launch it. Identifiers must match the ones exposed in the editor preferences.
- */
-const ideLaunchers: Record<string, { cli: string; macApp?: string }> = {
-	code: { cli: "code", macApp: "Visual Studio Code" },
-	cursor: { cli: "cursor", macApp: "Cursor" },
-	subl: { cli: "subl", macApp: "Sublime Text" },
-	phpstorm: { cli: "phpstorm", macApp: "PhpStorm" },
-	webstorm: { cli: "webstorm", macApp: "WebStorm" },
-	idea: { cli: "idea", macApp: "IntelliJ IDEA" },
-};
-
-/**
- * Tries to open the given path with the IDE matching the given identifier.
- * Returns true when the IDE could be launched, false otherwise.
- */
-async function tryLaunchIde(ide: string, normalizedPath: string): Promise<boolean> {
-	const launcher = ideLaunchers[ide];
-	if (!launcher) {
-		return false;
-	}
-
-	// Prefer the CLI command when available (works on all platforms).
-	if (await checkCommandAvailable(launcher.cli)) {
-		if (await runCommand(`${launcher.cli} "${normalizedPath}"`)) {
-			return true;
-		}
-	}
-
-	// On macOS, fallback to launching the application by its name.
-	if (platform() === "darwin" && launcher.macApp) {
-		return runCommand(`open -a "${launcher.macApp}" "${normalizedPath}"`);
-	}
-
-	return false;
-}
-
-async function openInIde(path: string, isDirectory: boolean, ide?: string): Promise<void> {
-	const isWindows = platform() === "win32";
-	const normalizedPath = isWindows ? path.replace(/\//g, "\\") : path.replace(/\\/g, "/");
-
-	// Open with the system default application when explicitly requested.
-	if (ide === "system") {
-		shell.openPath(normalizedPath);
-		return;
-	}
-
-	// When a specific IDE is selected in the preferences, try it first.
-	if (ide && ide !== "auto" && ideLaunchers[ide]) {
-		if (await tryLaunchIde(ide, normalizedPath)) {
-			return;
-		}
-		// Fall through to auto-detection if the selected IDE could not be launched.
-	}
-
-	if (isDirectory) {
-		// Try to open the directory in one of the CLI-based IDEs (works on all platforms).
-		for (const command of ["code", "cursor", "subl"]) {
-			if (await checkCommandAvailable(command)) {
-				if (await runCommand(`${command} "${normalizedPath}"`)) {
-					return;
-				}
-			}
-		}
-
-		// On macOS, try JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA).
-		if (platform() === "darwin") {
-			for (const app of ["PhpStorm", "WebStorm", "IntelliJ IDEA", "IntelliJ IDEA CE"]) {
-				if (await runCommand(`open -a "${app}" "${normalizedPath}"`)) {
-					return;
-				}
-			}
-		}
-
-		// On Windows, try JetBrains IDEs via CLI.
-		if (isWindows) {
-			for (const command of ["phpstorm", "webstorm", "idea"]) {
-				if (await checkCommandAvailable(command)) {
-					if (await runCommand(`${command} "${normalizedPath}"`)) {
-						return;
-					}
-				}
-			}
-		}
-
-		// Fallback: open with default application.
-		shell.openPath(normalizedPath);
-	} else {
-		// For files, use shell.openPath which uses OS default application.
-		shell.openPath(normalizedPath);
-	}
-}
 
 ipcMain.on("editor:open-with", async (_, item, ide) => {
 	try {

--- a/editor/src/tools/ide.ts
+++ b/editor/src/tools/ide.ts
@@ -1,0 +1,125 @@
+import { platform } from "os";
+import { shell } from "electron";
+
+import { executeAsync } from "./process";
+
+/**
+ * Runs the given command using `executeAsync` (which also fixes the PATH on macOS so CLI tools
+ * launched from the bundled app can be resolved). Resolves true on success, false otherwise.
+ */
+async function runCommand(command: string): Promise<boolean> {
+	try {
+		await executeAsync(command);
+		return true;
+	} catch (e) {
+		return false;
+	}
+}
+
+/**
+ * Returns wether or not the given CLI command is available on the system.
+ */
+async function checkCommandAvailable(command: string): Promise<boolean> {
+	return runCommand(`${command} --version`);
+}
+
+/**
+ * Defines for each supported IDE identifier the CLI command and the macOS application name
+ * used to launch it. Identifiers must match the ones exposed in the editor preferences.
+ */
+const ideLaunchers: Record<string, { cli: string; macApp?: string }> = {
+	code: { cli: "code", macApp: "Visual Studio Code" },
+	cursor: { cli: "cursor", macApp: "Cursor" },
+	subl: { cli: "subl", macApp: "Sublime Text" },
+	phpstorm: { cli: "phpstorm", macApp: "PhpStorm" },
+	webstorm: { cli: "webstorm", macApp: "WebStorm" },
+	idea: { cli: "idea", macApp: "IntelliJ IDEA" },
+};
+
+/**
+ * Tries to open the given path with the IDE matching the given identifier.
+ * Returns true when the IDE could be launched, false otherwise.
+ */
+async function tryLaunchIde(ide: string, normalizedPath: string): Promise<boolean> {
+	const launcher = ideLaunchers[ide];
+	if (!launcher) {
+		return false;
+	}
+
+	// Prefer the CLI command when available (works on all platforms).
+	if (await checkCommandAvailable(launcher.cli)) {
+		if (await runCommand(`${launcher.cli} "${normalizedPath}"`)) {
+			return true;
+		}
+	}
+
+	// On macOS, fallback to launching the application by its name.
+	if (platform() === "darwin" && launcher.macApp) {
+		return runCommand(`open -a "${launcher.macApp}" "${normalizedPath}"`);
+	}
+
+	return false;
+}
+
+/**
+ * Opens the given path (file or folder) in an IDE.
+ * @param path defines the absolute path to the file or folder to open.
+ * @param isDirectory defines wether or not the given path points to a directory.
+ * @param ide defines the identifier of the preferred IDE to use. When set to "auto" (or omitted)
+ * the first available IDE is detected and used. When set to "system" the OS default application is used.
+ */
+export async function openInIde(path: string, isDirectory: boolean, ide?: string): Promise<void> {
+	const isWindows = platform() === "win32";
+	const normalizedPath = isWindows ? path.replace(/\//g, "\\") : path.replace(/\\/g, "/");
+
+	// Open with the system default application when explicitly requested.
+	if (ide === "system") {
+		shell.openPath(normalizedPath);
+		return;
+	}
+
+	// When a specific IDE is selected in the preferences, try it first.
+	if (ide && ide !== "auto" && ideLaunchers[ide]) {
+		if (await tryLaunchIde(ide, normalizedPath)) {
+			return;
+		}
+		// Fall through to auto-detection if the selected IDE could not be launched.
+	}
+
+	if (isDirectory) {
+		// Try to open the directory in one of the CLI-based IDEs (works on all platforms).
+		for (const command of ["code", "cursor", "subl"]) {
+			if (await checkCommandAvailable(command)) {
+				if (await runCommand(`${command} "${normalizedPath}"`)) {
+					return;
+				}
+			}
+		}
+
+		// On macOS, try JetBrains IDEs (PhpStorm, WebStorm, IntelliJ IDEA).
+		if (platform() === "darwin") {
+			for (const app of ["PhpStorm", "WebStorm", "IntelliJ IDEA", "IntelliJ IDEA CE"]) {
+				if (await runCommand(`open -a "${app}" "${normalizedPath}"`)) {
+					return;
+				}
+			}
+		}
+
+		// On Windows, try JetBrains IDEs via CLI.
+		if (isWindows) {
+			for (const command of ["phpstorm", "webstorm", "idea"]) {
+				if (await checkCommandAvailable(command)) {
+					if (await runCommand(`${command} "${normalizedPath}"`)) {
+						return;
+					}
+				}
+			}
+		}
+
+		// Fallback: open with default application.
+		shell.openPath(normalizedPath);
+	} else {
+		// For files, use shell.openPath which uses OS default application.
+		shell.openPath(normalizedPath);
+	}
+}

--- a/editor/src/tools/ide.ts
+++ b/editor/src/tools/ide.ts
@@ -1,16 +1,19 @@
 import { platform } from "os";
 import { shell } from "electron";
 
-import { executeAsync } from "./process";
+import { execNodePty } from "./node-pty";
+import { tryGetDefaultIdeFromLocalStorage } from "./local-storage";
 
 /**
- * Runs the given command using `executeAsync` (which also fixes the PATH on macOS so CLI tools
- * launched from the bundled app can be resolved). Resolves true on success, false otherwise.
+ * Runs the given command in a node-pty process so it is detached from the editor process: the
+ * launched IDE keeps running even if the editor is closed (same approach as the VSCode launcher).
+ * Resolves true when the command exited with a success code, false otherwise.
  */
 async function runCommand(command: string): Promise<boolean> {
 	try {
-		await executeAsync(command);
-		return true;
+		const p = await execNodePty(command);
+		const code = await p.wait();
+		return code === 0;
 	} catch (e) {
 		return false;
 	}
@@ -65,10 +68,11 @@ async function tryLaunchIde(ide: string, normalizedPath: string): Promise<boolea
  * Opens the given path (file or folder) in an IDE.
  * @param path defines the absolute path to the file or folder to open.
  * @param isDirectory defines wether or not the given path points to a directory.
- * @param ide defines the identifier of the preferred IDE to use. When set to "auto" (or omitted)
- * the first available IDE is detected and used. When set to "system" the OS default application is used.
+ * @param ide defines the identifier of the preferred IDE to use. Defaults to the one configured in
+ * the editor preferences. When set to "auto" the first available IDE is detected and used. When set
+ * to "system" the OS default application is used.
  */
-export async function openInIde(path: string, isDirectory: boolean, ide?: string): Promise<void> {
+export async function openInIde(path: string, isDirectory: boolean, ide: string = tryGetDefaultIdeFromLocalStorage()): Promise<void> {
 	const isWindows = platform() === "win32";
 	const normalizedPath = isWindows ? path.replace(/\//g, "\\") : path.replace(/\\/g, "/");
 

--- a/editor/src/tools/local-storage.ts
+++ b/editor/src/tools/local-storage.ts
@@ -89,6 +89,45 @@ export function trySetCloseDashboardOnProjectOpenInLocalStorage(enabled: boolean
 }
 
 /**
+ * Defines the list of IDEs that can be selected as the default IDE used when opening
+ * a project or a file/folder from the editor.
+ */
+export const defaultIdeOptions = [
+	{ id: "auto", label: "Auto (detect installed)" },
+	{ id: "code", label: "Visual Studio Code" },
+	{ id: "cursor", label: "Cursor" },
+	{ id: "subl", label: "Sublime Text" },
+	{ id: "phpstorm", label: "PhpStorm" },
+	{ id: "webstorm", label: "WebStorm" },
+	{ id: "idea", label: "IntelliJ IDEA" },
+	{ id: "system", label: "System Default Application" },
+] as const;
+
+/**
+ * Returns the identifier of the default IDE to use when opening a project, file or folder.
+ * Defaults to "auto" when nothing is stored or the local storage can't be accessed.
+ */
+export function tryGetDefaultIdeFromLocalStorage(): string {
+	try {
+		return localStorage.getItem("babylonjs-editor-default-ide") ?? "auto";
+	} catch (e) {
+		return "auto";
+	}
+}
+
+/**
+ * Sets the identifier of the default IDE to use when opening a project, file or folder.
+ * @param ide defines the identifier of the IDE to set as the default one.
+ */
+export function trySetDefaultIdeInLocalStorage(ide: string): void {
+	try {
+		localStorage.setItem("babylonjs-editor-default-ide", ide);
+	} catch (e) {
+		// Catch silently.
+	}
+}
+
+/**
  * Returns the terminal path stored in the local storage, or null if it fails to access the local storage or if no terminal path is stored.
  */
 export function tryGetTerminalFromLocalStorage(): string | null {


### PR DESCRIPTION
## Summary
This PR adds an **"Open in Default IDE"** action that lets users open the current project,
folder, or file in their editor of choice, and introduces a **Default IDE** preference so
users can pick which IDE that action uses. Previously the only built-in shortcut was
"Open in Visual Studio Code", which didn't help users working in other editors (Cursor,
Sublime Text, or JetBrains IDEs like PhpStorm/WebStorm/IntelliJ IDEA). The IDE is now
launched detached from the editor process so it stays open even if the editor is closed.

## Changes Made

### "Open in Default IDE" action
- Added an "Open in Default IDE" entry to the toolbar menu, the native application menu,
  the assets browser context menu, and the dashboard project items.
- The action opens the relevant project folder (or file) in the user's selected IDE.

### Default IDE preference
- Added a "Default IDE" selector in Edit Preferences with the options: Auto (detect installed),
  Visual Studio Code, Cursor, Sublime Text, PhpStorm, WebStorm, IntelliJ IDEA, and
  System Default Application.
- The choice is persisted to `localStorage`, consistent with the other editor preferences
  (theme, experimental features, etc.).
- "Auto" detects the first installed IDE; "System Default" opens with the OS default app.

### IDE launching module (`tools/ide.ts`)
- Extracted all IDE-opening logic into a dedicated `tools/ide.ts` module, keeping the
  electron shell IPC handlers thin.
- Launch and detection commands run through `node-pty` (the same approach used by the
  VSCode launcher) so the IDE runs detached from the editor and keeps running after the
  editor is closed — and so CLI tools resolve correctly when the app is launched from
  Finder/Dock on macOS.
- If the selected IDE can't be launched, it gracefully falls back to auto-detection, then
  to the OS default application.

## Benefits
- Users can open their project in whatever IDE they actually use, not just VS Code.
- The chosen IDE is remembered across sessions, so the action is one click every time.
- The launched IDE stays open independently of the editor's lifecycle, avoiding the
  surprise of an editor being closed when the app is quit.
- Cross-platform support (macOS and Windows) with sensible auto-detection and fallbacks.